### PR TITLE
fix: rerun the running script with sudo instead of npm start

### DIFF
--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import type {
   Choice,
   ICommandResult,
@@ -87,15 +88,17 @@ export class CliUserInterface implements IUserInterface {
   }
 
   private async executeSudo(): Promise<void> {
-    try {
-      const { execSync } = require('node:child_process');
-      const args = process.argv.slice(2).join(' ');
-      execSync(`sudo ${process.argv[0]} ${process.argv[1]} ${args}`, { stdio: 'inherit' });
-      process.exit(0);
-    } catch (_error) {
+    // シェルを介さず引数を配列で渡す（プロファイル名に空白等が入っても壊れない）
+    const result = spawnSync('sudo', [process.argv[0], process.argv[1], ...process.argv.slice(2)], {
+      stdio: 'inherit',
+    });
+
+    if (result.error || result.status !== 0) {
       this.showMessage('Failed to execute with sudo', 'error');
       process.exit(1);
     }
+
+    process.exit(0);
   }
 
   private handleConfirmationRequired(): void {

--- a/src/cli/ui/InteractiveUserInterface.ts
+++ b/src/cli/ui/InteractiveUserInterface.ts
@@ -170,7 +170,7 @@ export class InteractiveUserInterface implements IUserInterface {
       } else {
         this.showMessage('Available profiles:', 'info');
         for (const profile of profiles) {
-          const status = profile.isActive ? ' (current)' : '';
+          const status = profile.isCurrent ? ' (current)' : '';
           this.showMessage(`  ${profile.name}${status}`, 'info');
         }
       }
@@ -191,7 +191,7 @@ export class InteractiveUserInterface implements IUserInterface {
       return;
     }
 
-    const switchableProfiles = listData.profiles.filter((p) => !p.isActive);
+    const switchableProfiles = listData.profiles.filter((p) => !p.isCurrent);
     if (switchableProfiles.length === 0) {
       this.showMessage('No other profiles available to switch to', 'info');
       return;

--- a/src/infrastructure/PermissionChecker.ts
+++ b/src/infrastructure/PermissionChecker.ts
@@ -77,13 +77,7 @@ export class PermissionChecker implements IPermissionChecker {
     const executablePath = process.argv[0]; // node path
     const scriptPath = process.argv[1]; // hostswitch.js path
 
-    // npm経由で実行されている場合の検出
-    if (scriptPath.includes('npm') || process.env.npm_execpath) {
-      // npm start -- switch profile -> sudo npm start -- switch profile
-      return ['sudo', 'npm', 'start', '--', ...args];
-    } else {
-      // direct execution -> sudo node hostswitch.js switch profile
-      return ['sudo', executablePath, scriptPath, ...args];
-    }
+    // npm run 経由でも argv[1] は実行中のスクリプトを指すので、常にそれを再実行する
+    return ['sudo', executablePath, scriptPath, ...args];
   }
 }

--- a/src/infrastructure/__tests__/PermissionChecker.test.ts
+++ b/src/infrastructure/__tests__/PermissionChecker.test.ts
@@ -212,11 +212,11 @@ describe('PermissionChecker', () => {
       expect(result.message).toBe('Failed to execute sudo: Command not found');
     });
 
-    it('npm経由での実行を検出してsudo npmコマンドを構築', async () => {
-      // npm経由の実行をシミュレート
+    it('npm script経由(npm_execpath あり)でも実行中のスクリプトを再実行する', async () => {
+      // npm run 経由でも argv[1] は dist/hostswitch.js なのでそのまま再実行できる
       const originalArgv = process.argv;
       const originalEnv = process.env.npm_execpath;
-      process.argv = ['/usr/bin/node', '/path/to/npm/script'];
+      process.argv = ['/usr/bin/node', '/path/to/dist/hostswitch.js'];
       process.env.npm_execpath = '/usr/bin/npm';
 
       const mockChild = {
@@ -232,7 +232,7 @@ describe('PermissionChecker', () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         'sudo',
-        ['npm', 'start', '--', 'switch', 'dev'],
+        ['/usr/bin/node', '/path/to/dist/hostswitch.js', 'switch', 'dev'],
         expect.any(Object)
       );
 
@@ -243,6 +243,35 @@ describe('PermissionChecker', () => {
       } else {
         delete process.env.npm_execpath;
       }
+    });
+
+    it('インストールパスに npm を含んでも実行中のスクリプトを再実行する', async () => {
+      // mise の install 先は npm-<pkg> を含むため、パスの部分一致で npm 起動と誤判定されていた
+      const originalArgv = process.argv;
+      const misePath =
+        '/home/user/.local/share/mise/installs/npm-milkmaccya2-hostswitch/1.2.10/bin/hostswitch';
+      process.argv = ['/usr/bin/node', misePath];
+      delete process.env.npm_execpath;
+
+      const mockChild = {
+        on: vi.fn((event: string, callback: (code: number | null) => void) => {
+          if (event === 'exit') {
+            setTimeout(() => callback(0), 10);
+          }
+        }),
+      } as unknown as ReturnType<typeof spawn>;
+      mockSpawn.mockReturnValue(mockChild);
+
+      await permissionChecker.rerunWithSudo(['switch', 'dev']);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'sudo',
+        ['/usr/bin/node', misePath, 'switch', 'dev'],
+        expect.any(Object)
+      );
+
+      // 復元
+      process.argv = originalArgv;
     });
 
     it('直接実行の場合はsudo nodeコマンドを構築', async () => {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -70,7 +70,6 @@ export interface CreateProfileResult {
 export interface ProfileInfo {
   name: string;
   isCurrent: boolean;
-  isActive?: boolean;
 }
 
 export interface DeleteResult {


### PR DESCRIPTION
## Summary

Interactive mode never switched the hosts file. Selecting *Switch profile* ran `sudo npm start -- switch <name>` in the current working directory instead of re-running hostswitch itself.

## Root cause

`buildSudoCommand` decided "launched via npm" from a substring match on `process.argv[1]`.

```ts
if (scriptPath.includes('npm') || process.env.npm_execpath) {
  return ['sudo', 'npm', 'start', '--', ...args];
}
```

Any install path containing `npm` takes that branch. mise installs npm packages under `~/.local/share/mise/installs/npm-<package>/<version>/`, so an install via mise always matched. The npm debug log left behind by the failed run:

```
8  verbose argv "start" "--" "switch" "CustomLogger"
19 verbose cwd /Users/…/some-directory
13 error code ENOENT   # no package.json there
```

Under `npm run` the value of `argv[1]` is still `dist/hostswitch.js`, so the npm branch was never needed — re-executing `argv[1]` covers both launch styles.

## Changes

| File | Change |
|---|---|
| `infrastructure/PermissionChecker.ts` | Drop the npm branch; always `sudo <argv[0]> <argv[1]> ...args` |
| `cli/ui/CliUserInterface.ts` | `execSync` with an interpolated shell string to `spawnSync` with an argument array |
| `cli/ui/InteractiveUserInterface.ts` | Read `isCurrent` instead of `isActive`, 2 places |
| `interfaces/index.ts` | Remove `ProfileInfo.isActive` |

`ProfileInfo` carried both `isCurrent: boolean` and an optional `isActive?: boolean` that nothing ever assigned. Interactive mode read `isActive`, so the current profile was never marked `(current)` in `List all profiles` and appeared in its own `Switch profile` list. The optional field kept the type checker quiet.

## Points to review

- The npm branch is removed rather than narrowed. Re-running `argv[1]` is correct for `npm start` too, so nothing is lost, but the old behaviour of shelling out to `npm start` is gone.
- `CliUserInterface.executeSudo` now exits with `process.exit(1)` when `spawnSync` reports a non-zero status, matching the previous `execSync` throw path.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 171 tests |
| `npm run build` | pass |

Two tests added to `PermissionChecker.test.ts`.

| Test | Asserts |
|---|---|
| `インストールパスに npm を含んでも実行中のスクリプトを再実行する` | A mise-style path builds `sudo <node> <script> switch dev` |
| `npm script経由(npm_execpath あり)でも実行中のスクリプトを再実行する` | Replaces the old test that asserted `sudo npm start` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)