### PR TITLE
feat: offer to apply the edited profile when it is the current one

### DIFF
--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -188,11 +188,17 @@ export class HostSwitchFacade {
       }
 
       const profilePath = this.hostSwitchService.getProfilePath(name);
+      const isCurrent = this.hostSwitchService.getCurrentProfile() === name;
       await this.processManager.openEditor('vi', profilePath);
+
+      // 編集しただけでは hosts ファイルは変わらないため、current の編集は適用が必要になる
+      const requiresApply = isCurrent && !this.hostSwitchService.isProfileApplied(name);
 
       return {
         success: true,
         message: `Profile "${name}" edited successfully`,
+        requiresApply,
+        profileName: name,
       };
     } catch (error) {
       return {

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -25,6 +25,7 @@ describe('HostSwitchFacade', () => {
     getProfilePath: ReturnType<typeof vi.fn>;
     getCurrentProfile: ReturnType<typeof vi.fn>;
     getConfig: ReturnType<typeof vi.fn>;
+    isProfileApplied: ReturnType<typeof vi.fn>;
   };
   let _mockLogger: ILogger;
   let mockProcessManager: IProcessManager;
@@ -41,6 +42,7 @@ describe('HostSwitchFacade', () => {
       getProfilePath: vi.fn(),
       getCurrentProfile: vi.fn(),
       getConfig: vi.fn().mockReturnValue({ hostsPath: '/etc/hosts' }),
+      isProfileApplied: vi.fn().mockReturnValue(true),
     };
 
     _mockLogger = {
@@ -259,6 +261,44 @@ describe('HostSwitchFacade', () => {
       expect(result.success).toBe(true);
       expect(result.message).toBe('Profile "local" edited successfully');
       expect(mockProcessManager.openEditor).toHaveBeenCalledWith('vi', '/path/to/profile');
+    });
+
+    it('should flag apply when editing the current profile leaves hosts stale', async () => {
+      vi.mocked(mockService.profileExists).mockReturnValue(true);
+      vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
+      vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
+      mockService.getCurrentProfile.mockReturnValue('local');
+      mockService.isProfileApplied.mockReturnValue(false);
+
+      const result = await facade.editProfile('local');
+
+      expect(result.success).toBe(true);
+      expect(result.requiresApply).toBe(true);
+      expect(result.profileName).toBe('local');
+    });
+
+    it('should not flag apply when the current profile is already applied', async () => {
+      vi.mocked(mockService.profileExists).mockReturnValue(true);
+      vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
+      vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
+      mockService.getCurrentProfile.mockReturnValue('local');
+      mockService.isProfileApplied.mockReturnValue(true);
+
+      const result = await facade.editProfile('local');
+
+      expect(result.requiresApply).toBe(false);
+    });
+
+    it('should not read hosts when editing a profile that is not current', async () => {
+      vi.mocked(mockService.profileExists).mockReturnValue(true);
+      vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
+      vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
+      mockService.getCurrentProfile.mockReturnValue('staging');
+
+      const result = await facade.editProfile('local');
+
+      expect(result.requiresApply).toBe(false);
+      expect(mockService.isProfileApplied).not.toHaveBeenCalled();
     });
 
     it('should handle editor errors', async () => {

--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -116,6 +116,13 @@ export class CliUserInterface implements IUserInterface {
       if (result.message) {
         this.showMessage(result.message, 'success');
       }
+      // CLI モードは確認プロンプトを持たないため、適用は switch に委ねる
+      if (result.requiresApply && result.profileName) {
+        this.showMessage(
+          `Run \`hostswitch switch ${result.profileName}\` to apply to /etc/hosts.`,
+          'warning'
+        );
+      }
     } else {
       this.showMessage(result.message || 'Operation failed', 'error');
       process.exit(1);

--- a/src/cli/ui/InteractiveUserInterface.ts
+++ b/src/cli/ui/InteractiveUserInterface.ts
@@ -191,14 +191,9 @@ export class InteractiveUserInterface implements IUserInterface {
       return;
     }
 
-    const switchableProfiles = listData.profiles.filter((p) => !p.isCurrent);
-    if (switchableProfiles.length === 0) {
-      this.showMessage('No other profiles available to switch to', 'info');
-      return;
-    }
-
-    const choices: Choice<string>[] = switchableProfiles.map((p) => ({
-      name: p.name,
+    // current も残す。編集した profile を選び直して再適用できるようにする
+    const choices: Choice<string>[] = listData.profiles.map((p) => ({
+      name: p.isCurrent ? `${p.name} (current, re-apply)` : p.name,
       value: p.name,
     }));
 
@@ -241,6 +236,21 @@ export class InteractiveUserInterface implements IUserInterface {
     const profileName = await this.promptSelect('Select profile to edit:', choices);
     const result = await this.facade.editProfile(profileName);
     await this.handleCommandResult(result);
+
+    if (!result.success || !result.requiresApply) {
+      return;
+    }
+
+    const confirmed = await this.promptConfirm(
+      `"${profileName}" is the current profile. Apply to /etc/hosts now?`
+    );
+    if (!confirmed) {
+      this.showMessage(`Run \`hostswitch switch ${profileName}\` to apply.`, 'info');
+      return;
+    }
+
+    const switchResult = await this.facade.switchProfile(profileName);
+    await this.handleCommandResult(switchResult);
   }
 
   private async handleShowProfile(): Promise<void> {

--- a/src/cli/ui/__tests__/UserInterface.test.ts
+++ b/src/cli/ui/__tests__/UserInterface.test.ts
@@ -134,6 +134,21 @@ describe('User Interface Classes', () => {
           'This operation requires confirmation. Add --force flag to proceed without confirmation.'
         );
       });
+
+      it('should hint the switch command when the edited profile needs applying', async () => {
+        const result: ICommandResult = {
+          success: true,
+          message: 'Profile "nothing" edited successfully',
+          requiresApply: true,
+          profileName: 'nothing',
+        };
+
+        await cliUI.handleCommandResult(result);
+
+        expect(mockLogger.warning).toHaveBeenCalledWith(
+          'Run `hostswitch switch nothing` to apply to /etc/hosts.'
+        );
+      });
     });
   });
 
@@ -189,6 +204,108 @@ describe('User Interface Classes', () => {
             choices,
           },
         ]);
+      });
+    });
+
+    describe('run() - edit', () => {
+      const profiles = [
+        { name: 'nothing', isCurrent: true },
+        { name: 'dev', isCurrent: false },
+      ];
+
+      beforeEach(() => {
+        vi.mocked(mockFacade.getCurrentProfile).mockReturnValue('nothing');
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: { profiles },
+        });
+      });
+
+      it('current プロファイルを編集して未適用なら確認して適用する', async () => {
+        vi.mocked(mockFacade.editProfile).mockResolvedValue({
+          success: true,
+          message: 'Profile "nothing" edited successfully',
+          requiresApply: true,
+          profileName: 'nothing',
+        });
+        vi.mocked(mockFacade.switchProfile).mockResolvedValue({
+          success: true,
+          message: 'Switched to profile "nothing"',
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'edit' })
+          .mockResolvedValueOnce({ selected: 'nothing' })
+          .mockResolvedValueOnce({ confirmed: true });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.switchProfile).toHaveBeenCalledWith('nothing');
+      });
+
+      it('確認で拒否した場合は適用せずswitchコマンドを案内する', async () => {
+        vi.mocked(mockFacade.editProfile).mockResolvedValue({
+          success: true,
+          message: 'Profile "nothing" edited successfully',
+          requiresApply: true,
+          profileName: 'nothing',
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'edit' })
+          .mockResolvedValueOnce({ selected: 'nothing' })
+          .mockResolvedValueOnce({ confirmed: false });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.switchProfile).not.toHaveBeenCalled();
+        expect(mockLogger.info).toHaveBeenCalledWith('Run `hostswitch switch nothing` to apply.');
+      });
+
+      it('requiresApplyが無ければ確認しない', async () => {
+        vi.mocked(mockFacade.editProfile).mockResolvedValue({
+          success: true,
+          message: 'Profile "dev" edited successfully',
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'edit' })
+          .mockResolvedValueOnce({ selected: 'dev' });
+
+        await interactiveUI.run();
+
+        expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+        expect(mockFacade.switchProfile).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('run() - switch', () => {
+      it('切替先の一覧に current を re-apply として残す', async () => {
+        vi.mocked(mockFacade.getCurrentProfile).mockReturnValue('nothing');
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: {
+            profiles: [
+              { name: 'nothing', isCurrent: true },
+              { name: 'dev', isCurrent: false },
+            ],
+          },
+        });
+        vi.mocked(mockFacade.switchProfile).mockResolvedValue({
+          success: true,
+          message: 'Switched to profile "nothing"',
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'switch' })
+          .mockResolvedValueOnce({ selected: 'nothing' });
+
+        await interactiveUI.run();
+
+        const selectCall = vi.mocked(inquirer.prompt).mock.calls[1][0] as Array<{
+          choices: Array<{ name: string; value: string }>;
+        }>;
+        expect(selectCall[0].choices).toEqual([
+          { name: 'nothing (current, re-apply)', value: 'nothing' },
+          { name: 'dev', value: 'dev' },
+        ]);
+        expect(mockFacade.switchProfile).toHaveBeenCalledWith('nothing');
       });
     });
 

--- a/src/core/HostSwitchService.ts
+++ b/src/core/HostSwitchService.ts
@@ -121,6 +121,21 @@ export class HostSwitchService {
     return this.profileManager.profileExists(name);
   }
 
+  // プロファイルの内容が hosts ファイルに反映済みかどうか。
+  // どちらかが読めないときは true を返し、適用を促さない。
+  isProfileApplied(name: string): boolean {
+    const profile = this.profileManager.getProfileContent(name);
+    if (!profile.success || profile.content === undefined) {
+      return true;
+    }
+
+    try {
+      return this.fileSystem.readFileSync(this.config.hostsPath) === profile.content;
+    } catch (_err) {
+      return true;
+    }
+  }
+
   getProfilePath(name: string): string {
     return this.profileManager.getProfilePath(name);
   }

--- a/src/core/__tests__/HostSwitchService.test.ts
+++ b/src/core/__tests__/HostSwitchService.test.ts
@@ -261,4 +261,32 @@ describe('HostSwitchService - 統合テスト', () => {
       expect(result.requiresSudo).toBeUndefined();
     });
   });
+
+  describe('isProfileApplied()', () => {
+    it('プロファイルの内容がhostsと一致していればtrue', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'dev content');
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'dev content');
+
+      expect(service.isProfileApplied('dev')).toBe(true);
+    });
+
+    it('編集してhostsと差が出たらfalse', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'edited content');
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'dev content');
+
+      expect(service.isProfileApplied('dev')).toBe(false);
+    });
+
+    it('プロファイルが読めない場合は適用を促さない', () => {
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'dev content');
+
+      expect(service.isProfileApplied('missing')).toBe(true);
+    });
+
+    it('hostsが読めない場合は適用を促さない', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'dev content');
+
+      expect(service.isProfileApplied('dev')).toBe(true);
+    });
+  });
 });

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -94,6 +94,8 @@ export interface ICommandResult {
   requiresConfirmation?: boolean;
   requiresSudo?: boolean;
   sudoCommand?: string;
+  requiresApply?: boolean;
+  profileName?: string;
 }
 
 export type MessageType = 'info' | 'error' | 'success' | 'warning';


### PR DESCRIPTION
## Summary

`edit` only writes `~/.hostswitch/profiles/<name>.hosts`. Nothing copies it to the hosts file, so editing the profile that is currently active left `/etc/hosts` stale until the next `switch`.

## Behaviour

| Mode | Editing the current profile when it no longer matches `/etc/hosts` |
|---|---|
| Interactive | Asks `"<name>" is the current profile. Apply to /etc/hosts now?` and applies through the existing switch path on yes |
| CLI `hostswitch edit <name>` | Prints ``Run `hostswitch switch <name>` to apply to /etc/hosts.`` |

CLI mode does not prompt for two reasons. `CliUserInterface` states as its contract that prompts are unsupported, and its sudo re-exec replays `process.argv`, so entering the apply step from `edit` would re-open the editor as root. Interactive mode builds `switch <name>` explicitly, which is safe.

## Changes

| File | Change |
|---|---|
| `core/HostSwitchService.ts` | Add `isProfileApplied(name)`: compares the profile content with the hosts file |
| `cli/HostSwitchFacade.ts` | `editProfile` returns `requiresApply` / `profileName` |
| `cli/ui/InteractiveUserInterface.ts` | Confirm and apply after edit; keep the current profile in the switch menu as `(current, re-apply)` |
| `cli/ui/CliUserInterface.ts` | Print the switch hint on `requiresApply` |
| `interfaces/index.ts` | Add `requiresApply` / `profileName` to `ICommandResult` |

The staleness check compares the profile content against `/etc/hosts` rather than diffing the file before and after the editor. That answers the same question when the edit is reverted, and when the hosts file was changed outside hostswitch. If either side cannot be read it reports applied, so nothing is suggested.

> [!NOTE]
> #63 stopped listing the current profile in the interactive switch menu, which had been the only way to re-apply an edited profile. This restores it as an explicit `(current, re-apply)` entry.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 183 tests |
| `npm run build` | pass |

`isProfileApplied` was also exercised against a real `~/.hostswitch`: the applied current profile reported `true`, two edited profiles `false`, an unknown name `true`.

The step that runs after the editor closes involves `vi` and sudo, so it is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)