### PR TITLE
feat: respect $EDITOR when editing a profile

### DIFF
--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -189,7 +189,8 @@ export class HostSwitchFacade {
 
       const profilePath = this.hostSwitchService.getProfilePath(name);
       const isCurrent = this.hostSwitchService.getCurrentProfile() === name;
-      await this.processManager.openEditor('vi', profilePath);
+      const editor = process.env.EDITOR || 'vi';
+      await this.processManager.openEditor(editor, profilePath);
 
       // 編集しただけでは hosts ファイルは変わらないため、current の編集は適用が必要になる
       const requiresApply = isCurrent && !this.hostSwitchService.isProfileApplied(name);

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HostSwitchService } from '../../core/HostSwitchService';
 import type {
   CreateProfileResult,
@@ -251,7 +251,21 @@ describe('HostSwitchFacade', () => {
   });
 
   describe('editProfile', () => {
-    it('should open editor for profile', async () => {
+    const originalEditor = process.env.EDITOR;
+
+    beforeEach(() => {
+      delete process.env.EDITOR;
+    });
+
+    afterEach(() => {
+      if (originalEditor === undefined) {
+        delete process.env.EDITOR;
+      } else {
+        process.env.EDITOR = originalEditor;
+      }
+    });
+
+    it('should fall back to vi when $EDITOR is not set', async () => {
       vi.mocked(mockService.profileExists).mockReturnValue(true);
       vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
       vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
@@ -260,6 +274,28 @@ describe('HostSwitchFacade', () => {
 
       expect(result.success).toBe(true);
       expect(result.message).toBe('Profile "local" edited successfully');
+      expect(mockProcessManager.openEditor).toHaveBeenCalledWith('vi', '/path/to/profile');
+    });
+
+    it('should use $EDITOR when set', async () => {
+      process.env.EDITOR = 'code --wait';
+      vi.mocked(mockService.profileExists).mockReturnValue(true);
+      vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
+      vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
+
+      await facade.editProfile('local');
+
+      expect(mockProcessManager.openEditor).toHaveBeenCalledWith('code --wait', '/path/to/profile');
+    });
+
+    it('should fall back to vi when $EDITOR is empty', async () => {
+      process.env.EDITOR = '';
+      vi.mocked(mockService.profileExists).mockReturnValue(true);
+      vi.mocked(mockService.getProfilePath).mockReturnValue('/path/to/profile');
+      vi.mocked(mockProcessManager.openEditor).mockResolvedValue();
+
+      await facade.editProfile('local');
+
       expect(mockProcessManager.openEditor).toHaveBeenCalledWith('vi', '/path/to/profile');
     });
 


### PR DESCRIPTION
## Summary

`editProfile` passed a hardcoded `'vi'` to the process manager, while the documentation states that `$EDITOR` is honoured.

| Source | Claim |
|---|---|
| `CLAUDE.md` line 188 | ``edit <name>``: Open profile in editor (uses $EDITOR or vi) |
| `CLAUDE.md` line 204 | Editor Selection: Uses `$EDITOR` environment variable, falls back to `vi` |

## Changes

`HostSwitchFacade.editProfile` now reads `process.env.EDITOR` and falls back to `vi`. An empty `$EDITOR` also falls back, so an exported-but-blank variable does not produce an empty command.

`ProcessManager.executeEditor` already passes the editor through a shell string, so values carrying flags such as `code --wait` keep working.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 185 tests |

Three tests cover the resolution order.

| Test | Asserts |
|---|---|
| `should fall back to vi when $EDITOR is not set` | `openEditor('vi', …)` |
| `should use $EDITOR when set` | `openEditor('code --wait', …)` |
| `should fall back to vi when $EDITOR is empty` | `openEditor('vi', …)` |

The tests clear and restore `$EDITOR` around each case so the result does not depend on the environment running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)