### PR TITLE
refactor: drive the sudo re-run from explicit args

### DIFF
--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -69,6 +69,7 @@ export class HostSwitchFacade {
           success: false,
           requiresSudo: true,
           sudoCommand: `sudo hostswitch switch ${name}`,
+          sudoArgs: ['switch', name],
           message: 'This operation requires sudo privileges',
         };
       }

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -149,6 +149,7 @@ describe('HostSwitchFacade', () => {
       expect(result.success).toBe(false);
       expect(result.requiresSudo).toBe(true);
       expect(result.sudoCommand).toBe('sudo hostswitch switch staging');
+      expect(result.sudoArgs).toEqual(['switch', 'staging']);
       expect(mockService.switchProfile).not.toHaveBeenCalled();
     });
 

--- a/src/cli/__tests__/Integration.test.ts
+++ b/src/cli/__tests__/Integration.test.ts
@@ -155,6 +155,7 @@ describe('Integration Tests', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch staging',
+        sudoArgs: ['switch', 'staging'],
         message: 'This operation requires sudo privileges.',
       });
 
@@ -172,6 +173,7 @@ describe('Integration Tests', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch production',
+        sudoArgs: ['switch', 'production'],
         message: 'This operation requires sudo privileges.',
       });
 
@@ -195,6 +197,7 @@ describe('Integration Tests', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch staging',
+        sudoArgs: ['switch', 'staging'],
         message: 'This operation requires sudo privileges.',
       });
 

--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -66,17 +66,19 @@ export class CliUserInterface implements IUserInterface {
   private async handleSudoRequired(result: ICommandResult): Promise<void> {
     this.showMessage('This operation requires sudo privileges. Rerunning with sudo...', 'info');
 
+    // 何を sudo で実行するかは呼び出し側が明示する。ここで現在の引数を流用すると
+    // hosts の書き換えを伴わない操作までそのまま root で再実行されてしまう
+    if (!result.sudoArgs) {
+      this.showMessage('No sudo command provided', 'error');
+      return;
+    }
+
     if (this.isTestEnvironment()) {
       this.showMessage('(Skipped in test environment)', 'info');
       return;
     }
 
-    if (!result.sudoCommand) {
-      this.showMessage('No sudo command provided', 'error');
-      return;
-    }
-
-    await this.executeSudo();
+    await this.executeSudo(result.sudoArgs);
   }
 
   private isTestEnvironment(): boolean {
@@ -87,9 +89,9 @@ export class CliUserInterface implements IUserInterface {
     );
   }
 
-  private async executeSudo(): Promise<void> {
+  private async executeSudo(args: string[]): Promise<void> {
     // シェルを介さず引数を配列で渡す（プロファイル名に空白等が入っても壊れない）
-    const result = spawnSync('sudo', [process.argv[0], process.argv[1], ...process.argv.slice(2)], {
+    const result = spawnSync('sudo', [process.argv[0], process.argv[1], ...args], {
       stdio: 'inherit',
     });
 

--- a/src/cli/ui/InteractiveUserInterface.ts
+++ b/src/cli/ui/InteractiveUserInterface.ts
@@ -312,23 +312,21 @@ export class InteractiveUserInterface implements IUserInterface {
   private async handleSudoRequired(result: ICommandResult): Promise<void> {
     this.showMessage('This operation requires sudo privileges.', 'warning');
 
-    if (result.sudoCommand?.includes('switch')) {
-      // sudo hostswitch switch profile-name の形式から profile-name を抽出
-      const parts = result.sudoCommand.split(' ');
-      const switchIndex = parts.indexOf('switch');
-      if (switchIndex >= 0 && switchIndex + 1 < parts.length) {
-        const profileName = parts[switchIndex + 1];
-        this.showMessage(`Switching to profile "${profileName}" with sudo...`, 'info');
-        try {
-          const sudoResult = await this.facade.switchProfileWithSudo(profileName);
-          await this.handleCommandResult(sudoResult);
-        } catch (error) {
-          this.showMessage(
-            `Failed to execute sudo command: ${error instanceof Error ? error.message : String(error)}`,
-            'error'
-          );
-        }
-      }
+    // 表示用の sudoCommand は形が変わりうるので、実行する操作は sudoArgs だけで決める
+    const [command, profileName] = result.sudoArgs ?? [];
+    if (command !== 'switch' || !profileName) {
+      return;
+    }
+
+    this.showMessage(`Switching to profile "${profileName}" with sudo...`, 'info');
+    try {
+      const sudoResult = await this.facade.switchProfileWithSudo(profileName);
+      await this.handleCommandResult(sudoResult);
+    } catch (error) {
+      this.showMessage(
+        `Failed to execute sudo command: ${error instanceof Error ? error.message : String(error)}`,
+        'error'
+      );
     }
   }
 }

--- a/src/cli/ui/__tests__/AutoSudo.test.ts
+++ b/src/cli/ui/__tests__/AutoSudo.test.ts
@@ -39,6 +39,7 @@ describe('Auto-Sudo Functionality', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch my-profile',
+        sudoArgs: ['switch', 'my-profile'],
       };
 
       await cliUI.handleCommandResult(result);
@@ -60,6 +61,7 @@ describe('Auto-Sudo Functionality', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch staging',
+        sudoArgs: ['switch', 'staging'],
       };
 
       await cliUI.handleCommandResult(result);
@@ -82,57 +84,57 @@ describe('Auto-Sudo Functionality', () => {
   });
 
   describe('InteractiveUserInterface Auto-Sudo', () => {
-    it('should extract profile name correctly from various sudo command formats', async () => {
+    it('should take the profile name from sudoArgs', async () => {
       vi.mocked(mockFacade.switchProfileWithSudo).mockResolvedValue({
         success: true,
         message: 'Success',
       });
 
-      // Test standard format
-      const result1: ICommandResult = {
+      const result: ICommandResult = {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch production',
+        sudoArgs: ['switch', 'production'],
       };
 
-      await interactiveUI.handleCommandResult(result1);
+      await interactiveUI.handleCommandResult(result);
+
       expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('production');
+    });
 
-      // Test with full path
-      const result2: ICommandResult = {
-        success: false,
-        requiresSudo: true,
-        sudoCommand: 'sudo /usr/local/bin/hostswitch switch development',
-      };
+    it('should not run the profile name through the displayed sudoCommand', async () => {
+      vi.mocked(mockFacade.switchProfileWithSudo).mockResolvedValue({
+        success: true,
+        message: 'Success',
+      });
 
-      await interactiveUI.handleCommandResult(result2);
-      expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('development');
-
-      // Test with node command
-      const result3: ICommandResult = {
+      // 表示用の文字列は絶対パスでも node 経由でも形が変わるので、判断材料にしない
+      const result: ICommandResult = {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo node /path/to/hostswitch.js switch staging',
+        sudoArgs: ['switch', 'production'],
       };
 
-      await interactiveUI.handleCommandResult(result3);
-      expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('staging');
+      await interactiveUI.handleCommandResult(result);
+
+      expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('production');
     });
 
     it('should not execute sudo for non-switch commands', async () => {
-      const commands = [
-        'sudo hostswitch list',
-        'sudo hostswitch create test',
-        'sudo hostswitch delete test',
-        'sudo hostswitch show test',
-        'sudo hostswitch edit test',
+      const argsList = [
+        ['list'],
+        ['create', 'test'],
+        ['delete', 'test'],
+        ['show', 'test'],
+        ['edit', 'test'],
       ];
 
-      for (const command of commands) {
+      for (const sudoArgs of argsList) {
         const result: ICommandResult = {
           success: false,
           requiresSudo: true,
-          sudoCommand: command,
+          sudoArgs,
         };
 
         await interactiveUI.handleCommandResult(result);
@@ -141,20 +143,14 @@ describe('Auto-Sudo Functionality', () => {
       expect(mockFacade.switchProfileWithSudo).not.toHaveBeenCalled();
     });
 
-    it('should handle malformed sudo commands gracefully', async () => {
-      const malformedCommands = [
-        'sudo',
-        'sudo hostswitch',
-        'sudo hostswitch switch',
-        '',
-        'malformed command',
-      ];
+    it('should handle incomplete sudoArgs gracefully', async () => {
+      const argsList: (string[] | undefined)[] = [undefined, [], ['switch'], ['switch', '']];
 
-      for (const command of malformedCommands) {
+      for (const sudoArgs of argsList) {
         const result: ICommandResult = {
           success: false,
           requiresSudo: true,
-          sudoCommand: command,
+          sudoArgs,
         };
 
         await interactiveUI.handleCommandResult(result);
@@ -170,6 +166,7 @@ describe('Auto-Sudo Functionality', () => {
         success: false,
         requiresSudo: true,
         sudoCommand: 'sudo hostswitch switch production',
+        sudoArgs: ['switch', 'production'],
       };
 
       // This should not throw
@@ -186,11 +183,11 @@ describe('Auto-Sudo Functionality', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should handle undefined sudoCommand', async () => {
+    it('should report a missing sudoArgs instead of replaying the current command', async () => {
       const result: ICommandResult = {
         success: false,
         requiresSudo: true,
-        // sudoCommand is undefined
+        // sudoArgs is undefined
       };
 
       await cliUI.handleCommandResult(result);
@@ -199,15 +196,17 @@ describe('Auto-Sudo Functionality', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         'This operation requires sudo privileges. Rerunning with sudo...'
       );
-      expect(mockLogger.info).toHaveBeenCalledWith('(Skipped in test environment)');
+      expect(mockLogger.error).toHaveBeenCalledWith('No sudo command provided');
+      expect(mockLogger.info).not.toHaveBeenCalledWith('(Skipped in test environment)');
       expect(mockLogger.warning).toHaveBeenCalledWith('This operation requires sudo privileges.');
+      expect(mockFacade.switchProfileWithSudo).not.toHaveBeenCalled();
     });
 
-    it('should handle empty sudoCommand', async () => {
+    it('should handle empty sudoArgs', async () => {
       const result: ICommandResult = {
         success: false,
         requiresSudo: true,
-        sudoCommand: '',
+        sudoArgs: [],
       };
 
       await interactiveUI.handleCommandResult(result);

--- a/src/cli/ui/__tests__/UserInterface.test.ts
+++ b/src/cli/ui/__tests__/UserInterface.test.ts
@@ -112,6 +112,7 @@ describe('User Interface Classes', () => {
           success: false,
           requiresSudo: true,
           sudoCommand: 'sudo hostswitch switch staging',
+          sudoArgs: ['switch', 'staging'],
         };
 
         await cliUI.handleCommandResult(result);
@@ -386,6 +387,7 @@ describe('User Interface Classes', () => {
           success: false,
           requiresSudo: true,
           sudoCommand: 'sudo hostswitch switch staging',
+          sudoArgs: ['switch', 'staging'],
         };
 
         await interactiveUI.handleCommandResult(result);
@@ -396,12 +398,12 @@ describe('User Interface Classes', () => {
         expect(mockLogger.success).toHaveBeenCalledWith('Switched to profile "staging"');
       });
 
-      it('should handle sudo command parsing edge cases', async () => {
-        // Test with malformed sudo command
+      it('should handle incomplete sudoArgs', async () => {
+        // プロファイル名が無い
         const result1: ICommandResult = {
           success: false,
           requiresSudo: true,
-          sudoCommand: 'sudo hostswitch', // No profile name
+          sudoArgs: ['switch'],
         };
 
         await interactiveUI.handleCommandResult(result1);
@@ -409,11 +411,11 @@ describe('User Interface Classes', () => {
         expect(mockLogger.warning).toHaveBeenCalledWith('This operation requires sudo privileges.');
         expect(mockFacade.switchProfileWithSudo).not.toHaveBeenCalled();
 
-        // Test with command that doesn't contain 'switch'
+        // switch 以外の操作
         const result2: ICommandResult = {
           success: false,
           requiresSudo: true,
-          sudoCommand: 'sudo hostswitch list',
+          sudoArgs: ['list'],
         };
 
         await interactiveUI.handleCommandResult(result2);
@@ -431,6 +433,7 @@ describe('User Interface Classes', () => {
           success: false,
           requiresSudo: true,
           sudoCommand: 'sudo hostswitch switch staging',
+          sudoArgs: ['switch', 'staging'],
         };
 
         await interactiveUI.handleCommandResult(result);
@@ -441,7 +444,7 @@ describe('User Interface Classes', () => {
         expect(mockLogger.error).toHaveBeenCalledWith('Sudo execution failed');
       });
 
-      it('should handle complex profile names with spaces or special characters', async () => {
+      it('should pass profile names containing spaces through untouched', async () => {
         vi.mocked(mockFacade.switchProfileWithSudo).mockResolvedValue({
           success: true,
           message: 'Switched successfully',
@@ -450,12 +453,13 @@ describe('User Interface Classes', () => {
         const result: ICommandResult = {
           success: false,
           requiresSudo: true,
-          sudoCommand: 'sudo hostswitch switch "complex-profile-name"',
+          sudoCommand: 'sudo hostswitch switch complex profile name',
+          sudoArgs: ['switch', 'complex profile name'],
         };
 
         await interactiveUI.handleCommandResult(result);
 
-        expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('"complex-profile-name"');
+        expect(mockFacade.switchProfileWithSudo).toHaveBeenCalledWith('complex profile name');
       });
     });
   });

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -93,7 +93,10 @@ export interface ICommandResult {
   data?: unknown;
   requiresConfirmation?: boolean;
   requiresSudo?: boolean;
+  // 表示用の文字列。sudo で何を実行するかの判断には使わない
   sudoCommand?: string;
+  // sudo で再実行する hostswitch の引数
+  sudoArgs?: string[];
   requiresApply?: boolean;
   profileName?: string;
 }


### PR DESCRIPTION
## Summary

Both user interfaces decided *what* to run under sudo from loose sources rather than from the result that raised the requirement.

| UI | Before | Problem |
|---|---|---|
| `CliUserInterface` | Replays `process.argv.slice(2)` | Any command reporting `requiresSudo` is re-executed verbatim as root |
| `InteractiveUserInterface` | Searches `sudoCommand` for `switch` and takes the next word | Quoting artifacts pass through as a profile name |

The CLI case is currently latent: only `switch` raises `requiresSudo`. It stops being latent as soon as another command can reach the apply step — `edit` would re-open the editor as root.

The interactive case is observable today. A profile name arriving as `"complex-profile-name"` in the string was handed to `switchProfileWithSudo` with the quotes still attached.

## Changes

| File | Change |
|---|---|
| `interfaces/index.ts` | Add `sudoArgs?: string[]`; document `sudoCommand` as display-only |
| `cli/HostSwitchFacade.ts` | Set `sudoArgs: ['switch', name]` where the sudo requirement is raised |
| `cli/ui/CliUserInterface.ts` | `executeSudo(args)` takes the args; a result without `sudoArgs` reports an error instead of replaying `process.argv` |
| `cli/ui/InteractiveUserInterface.ts` | Read the operation and profile name from `sudoArgs`; drop the string parsing |

`sudoCommand` is still produced and still what the user is shown. It is no longer read to decide behaviour.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 186 tests |
| `npm run build` | pass |

Tests that encoded the string parsing were rewritten against `sudoArgs`.

| Test | Now asserts |
|---|---|
| `should take the profile name from sudoArgs` | The name comes from the structured args |
| `should not run the profile name through the displayed sudoCommand` | A mismatched `sudoCommand` does not change the outcome |
| `should pass profile names containing spaces through untouched` | Replaces the case that expected `'"complex-profile-name"'` |
| `should handle incomplete sudoArgs gracefully` | `undefined` / `[]` / `['switch']` / `['switch', '']` do nothing |
| `should report a missing sudoArgs instead of replaying the current command` | CLI reports the missing command rather than re-running argv |

The `spawnSync` call itself stays untested: `isTestEnvironment()` short-circuits before it under vitest, as it did before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)