### PR TITLE
docs: align CLAUDE.md with the current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,11 +144,13 @@ src/
 - **FileSystemAdapter**: File system operations implementation
 - **ChalkLogger**: Console output with colors and formatting
 - **ProcessManager**: External process execution (editor)
+- **PermissionChecker**: sudo detection and re-running the CLI under sudo
 
 #### **Interface Layer** (`interfaces/`)
 - **IFileSystem**: File system abstraction for testing
 - **ILogger**: Logging abstraction
 - **IProcessManager**: Process execution abstraction
+- **IPermissionChecker**: sudo detection abstraction
 - Type definitions for data structures and configurations
 
 ### Dependency Injection
@@ -227,15 +229,12 @@ Build commands:
 
 ## Update Notification Feature
 
-HostSwitch includes automatic update checking using `update-notifier`:
-- **Automatic check**: Runs asynchronously on startup (24-hour cache)
-- **Non-intrusive**: Doesn't block user operations
-- **Disable option**: Set `HOSTSWITCH_NO_UPDATE_CHECK=true` to disable
-- **Implementation**: `UpdateChecker` class in `src/core/UpdateChecker.ts`
-
-## Workflow Reminders
-
-- タスクが終わるごとに@ARCHITECTURE_DIAGRAMS.md を更新する
+HostSwitch checks for a newer published version with `update-notifier`, called directly from `main()` in `src/hostswitch.ts`:
+- **Check**: Runs in a detached child process, so it never blocks an operation. `updateCheckInterval: 0` starts a check on every invocation
+- **Notification timing**: The check writes its result to a config store and the notifier reads that result on the *next* invocation, printing it when the process exits. A version published moments ago is reported one run later
+- **Requires a TTY**: Nothing is printed when stdout is not a TTY, so piping the output hides the notice
+- **Disabled when**: `NO_UPDATE_NOTIFIER` is present in the environment, `NODE_ENV=test`, `--no-update-notifier` is passed, or a CI environment is detected
+- **Suggested command**: `notify({ isGlobal: true })` makes the notice suggest `npm i -g @milkmaccya2/hostswitch`, whichever way the running copy was installed
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary

Three statements in `CLAUDE.md` no longer matched the code.

| Statement | Reality |
|---|---|
| `UpdateChecker` class in `src/core/UpdateChecker.ts` | Deleted in `57583d3` (v1.2.8). `update-notifier` is called directly from `main()` in `src/hostswitch.ts` |
| Set `HOSTSWITCH_NO_UPDATE_CHECK=true` to disable | No such variable exists anywhere in the source |
| Update `ARCHITECTURE_DIAGRAMS.md` after every task | Deleted in `a4e80d0` together with the other planning docs, and not gitignored, so nothing is there to update |

The 24-hour cache claim was also wrong: the call passes `updateCheckInterval: 0`.

## Changes

The update notification section now describes the configured behaviour, taken from the call site and from `update-notifier`'s own source.

| Aspect | Documented behaviour |
|---|---|
| Check | Detached child process, started on every invocation |
| Notification timing | Result is read on the next invocation and printed at process exit |
| Visibility | Requires stdout to be a TTY |
| Disabled when | `NO_UPDATE_NOTIFIER` present, `NODE_ENV=test`, `--no-update-notifier`, or CI detected |
| Suggested command | `npm i -g @milkmaccya2/hostswitch`, because `isGlobal: true` is passed |

The stale workflow reminder is removed. The pre-commit workflow already documented under *Development Workflow* (`npm run check`) is unaffected.

`PermissionChecker` and `IPermissionChecker` are added to the layer overview, which listed every other member of those two layers.

> [!NOTE]
> The suggested update command is documented as-is, not fixed. It is wrong for installs that are not plain global npm — a mise-managed install needs `mise upgrade npm:@milkmaccya2/hostswitch`. Changing it needs a decision on whether to detect the install method or to word the message neutrally.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 186 tests |

Documentation only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)