### PR TITLE
fix: stop presenting npm i -g as the update command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ HostSwitch checks for a newer published version with `update-notifier`, called d
 - **Notification timing**: The check writes its result to a config store and the notifier reads that result on the *next* invocation, printing it when the process exits. A version published moments ago is reported one run later
 - **Requires a TTY**: Nothing is printed when stdout is not a TTY, so piping the output hides the notice
 - **Disabled when**: `NO_UPDATE_NOTIFIER` is present in the environment, `NODE_ENV=test`, `--no-update-notifier` is passed, or a CI environment is detected
-- **Suggested command**: `notify({ isGlobal: true })` makes the notice suggest `npm i -g @milkmaccya2/hostswitch`, whichever way the running copy was installed
+- **Suggested command**: The install method is not detected, so a custom `notify({ message })` presents `npm i -g @milkmaccya2/hostswitch` as an example rather than as the command to run. `isGlobal: true` is what makes that example the global form
 
 ## Development Workflow
 

--- a/src/hostswitch.ts
+++ b/src/hostswitch.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import chalk from 'chalk';
 import { Command } from 'commander';
 import updateNotifier from 'update-notifier';
 import packageJson from '../package.json';
@@ -118,12 +119,19 @@ function parseCommands() {
 
 // アプリケーション起動
 async function main() {
-  // アップデートチェック
+  // アップデートチェック。
+  // 既定の文言は npm i -g を「実行すべきコマンド」として出すが、mise や volta などで
+  // 入れた場合は効かない。install に使ったツールが何かは判定しないので、例として示す。
+  const updateMessage =
+    `Update available ${chalk.dim('{currentVersion}')}${chalk.reset(' → ')}${chalk.green('{latestVersion}')}\n` +
+    'Update with the tool you used to install hostswitch, e.g.\n' +
+    chalk.cyan('{updateCommand}');
+
   updateNotifier({
     pkg: packageJson,
     updateCheckInterval: 0,
     shouldNotifyInNpmScript: true,
-  }).notify({ isGlobal: true });
+  }).notify({ isGlobal: true, message: updateMessage });
 
   const program = parseCommands();
 


### PR DESCRIPTION
## Summary

`update-notifier`'s default notice tells the user to run `npm i -g @milkmaccya2/hostswitch`. That does not update a copy installed through mise, volta, pnpm or Homebrew, and hostswitch cannot tell reliably which one was used.

The notice now names the tool the user installed with and shows the npm command as an example.

## Rendered output

Captured by running the built CLI with `process.stdout.isTTY` forced on and an isolated `XDG_CONFIG_HOME` holding a seeded update entry. Colours are stripped in the capture.

Before:

```
   ╭────────────────────────────────────────────────────╮
   │                                                    │
   │         Update available 1.2.12 → 1.2.13           │
   │   Run npm i -g @milkmaccya2/hostswitch to update   │
   │                                                    │
   ╰────────────────────────────────────────────────────╯
```

After:

```
   ╭───────────────────────────────────────────────────────────────╮
   │                                                               │
   │               Update available 1.2.12 → 1.2.13                │
   │   Update with the tool you used to install hostswitch, e.g.   │
   │               npm i -g @milkmaccya2/hostswitch                │
   │                                                               │
   ╰───────────────────────────────────────────────────────────────╯
```

The command sits on its own line. With the example inline, boxen wrapped it as `… e.g. npm i -g` / `@milkmaccya2/hostswitch`, splitting the command across two lines.

## Changes

| File | Change |
|---|---|
| `src/hostswitch.ts` | Pass a custom `message` to `notify()`, keeping the default's dim / green / cyan styling |
| `CLAUDE.md` | Update the line describing the suggested command |

## Points to review

Detecting the install method was the alternative. It would mean inferring from the path of the running script, which is the same kind of guess that caused #63 — mise installs under a directory whose name contains `npm`, and a substring test there sent every sudo re-run through `npm start`. Naming no specific tool avoids repeating that, at the cost of not handing the user an exact command.

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 186 tests |
| `npm run build` | pass |
| Rendered notice, before and after | shown above |

The notice lives in `main()`, which has no test coverage, so it is verified by rendering rather than by a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)