### PR TITLE
fix: quote the profile path passed to the editor

### DIFF
--- a/src/infrastructure/ProcessManager.ts
+++ b/src/infrastructure/ProcessManager.ts
@@ -5,7 +5,9 @@ export class ProcessManager implements IProcessManager {
   async executeEditor(editor: string, filePath: string): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
-        execSync(`${editor} ${filePath}`, { stdio: 'inherit' });
+        // editor は `code --wait` のようにフラグを含みうるのでシェルに解釈させる。
+        // パスは解釈させたくないので引用する
+        execSync(`${editor} ${this.quotePath(filePath)}`, { stdio: 'inherit' });
         resolve();
       } catch (err) {
         reject(err);
@@ -15,5 +17,14 @@ export class ProcessManager implements IProcessManager {
 
   async openEditor(editor: string, filePath: string): Promise<void> {
     return this.executeEditor(editor, filePath);
+  }
+
+  private quotePath(filePath: string): string {
+    if (process.platform === 'win32') {
+      return `"${filePath}"`;
+    }
+
+    // シングルクォートで囲み、含まれるシングルクォートは一度閉じて連結する
+    return `'${filePath.replace(/'/g, "'\\''")}'`;
   }
 }

--- a/src/infrastructure/__tests__/ProcessManager.test.ts
+++ b/src/infrastructure/__tests__/ProcessManager.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProcessManager } from '../ProcessManager';
 
 vi.mock('child_process');
@@ -14,20 +14,79 @@ describe('ProcessManager', () => {
   });
 
   describe('executeEditor()', () => {
+    const originalPlatform = process.platform;
+
+    const setPlatform = (value: string) => {
+      Object.defineProperty(process, 'platform', { value, writable: true });
+    };
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+    });
+
     it('エディタを正常に実行', async () => {
+      setPlatform('darwin');
       mockExecSync.mockReturnValue(Buffer.from(''));
 
       await manager.executeEditor('vi', '/test/file.txt');
 
-      expect(mockExecSync).toHaveBeenCalledWith('vi /test/file.txt', { stdio: 'inherit' });
+      expect(mockExecSync).toHaveBeenCalledWith("vi '/test/file.txt'", { stdio: 'inherit' });
     });
 
     it('複数の引数を持つエディタコマンドを実行', async () => {
+      setPlatform('darwin');
       mockExecSync.mockReturnValue(Buffer.from(''));
 
       await manager.executeEditor('code --wait', '/test/file.txt');
 
-      expect(mockExecSync).toHaveBeenCalledWith('code --wait /test/file.txt', { stdio: 'inherit' });
+      expect(mockExecSync).toHaveBeenCalledWith("code --wait '/test/file.txt'", {
+        stdio: 'inherit',
+      });
+    });
+
+    it('空白を含むパスでも1つの引数として渡す', async () => {
+      setPlatform('darwin');
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      await manager.executeEditor('vi', '/Users/my name/.hostswitch/profiles/dev.hosts');
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        "vi '/Users/my name/.hostswitch/profiles/dev.hosts'",
+        { stdio: 'inherit' }
+      );
+    });
+
+    it('シングルクォートを含むパスをエスケープする', async () => {
+      setPlatform('darwin');
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      await manager.executeEditor('vi', "/Users/o'brien/dev.hosts");
+
+      expect(mockExecSync).toHaveBeenCalledWith("vi '/Users/o'\\''brien/dev.hosts'", {
+        stdio: 'inherit',
+      });
+    });
+
+    it('シェルが展開する文字を含むパスをそのまま渡す', async () => {
+      setPlatform('darwin');
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      await manager.executeEditor('vi', '/Users/$USER/dev.hosts');
+
+      expect(mockExecSync).toHaveBeenCalledWith("vi '/Users/$USER/dev.hosts'", {
+        stdio: 'inherit',
+      });
+    });
+
+    it('Windowsではダブルクォートで囲む', async () => {
+      setPlatform('win32');
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      await manager.executeEditor('notepad', 'C:\\Users\\my name\\dev.hosts');
+
+      expect(mockExecSync).toHaveBeenCalledWith('notepad "C:\\Users\\my name\\dev.hosts"', {
+        stdio: 'inherit',
+      });
     });
 
     it('エディタ実行エラーを適切に処理', async () => {


### PR DESCRIPTION
## Summary

`executeEditor` interpolated the editor command and the profile path into one shell string, leaving the path unquoted.

```ts
execSync(`${editor} ${filePath}`, { stdio: 'inherit' });
```

The path is built from `os.homedir()`, so anything the shell treats specially in the home directory name reaches the shell.

## Observed behaviour

Both runs use a spy editor that records its arguments, with `HOME` pointed at a scratch directory.

| `HOME` | 1.2.13 | This branch |
|---|---|---|
| `…/ho me` | Two arguments: `…/ho` and `me/.hostswitch/profiles/spytest.hosts` | One argument, space intact |
| `…/$USER-dir` | Expanded to `…/hiroayok-dir/…`, so the editor opens a different path | `$USER-dir` preserved |

## Changes

`ProcessManager.quotePath` quotes the path before interpolation. The editor string is still handled by the shell, so values carrying flags such as `code --wait` keep working.

| Platform | Quoting |
|---|---|
| POSIX | Single quotes, with embedded `'` closed and re-opened as `'\''` |
| `win32` | Double quotes, since `cmd.exe` does not treat `'` as a quote character |

## Verification

| Command | Result |
|---|---|
| `npm run check` | pass — 14 files, 190 tests |
| `npm run build` | pass |
| Spy editor, before and after | shown above |

Four tests added to `ProcessManager.test.ts`: a path with a space, a path containing a single quote, a path containing `$USER`, and the `win32` form. The two existing tests now expect the quoted string.

> [!NOTE]
> Not addressed here: `CliUserInterface` still cannot prompt, so applying an edited current profile from CLI mode remains a printed hint rather than a confirmation. That needs the no-prompts contract revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)