### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a problem with hostswitch
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the
+        fields below — they're the ones we usually need to reproduce
+        hosts-file and permission issues.
+
+        Found a **security** issue (privilege escalation, unintended writes
+        while running with sudo, etc.)? Please use
+        [private vulnerability reporting](https://github.com/milkmaccya2/hostswitch/security/advisories/new)
+        instead of filing a public issue.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS and version
+      description: e.g. macOS 14.5, Ubuntu 22.04, Windows 11 (native or WSL2)
+      placeholder: macOS 14.5
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`
+      placeholder: v20.11.0
+    validations:
+      required: true
+
+  - type: input
+    id: hostswitch-version
+    attributes:
+      label: hostswitch version
+      description: Output of `hostswitch --version`
+      placeholder: 1.2.13
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - npm install -g (global)
+        - npx
+        - npm link (from source)
+        - Built/run from source directly
+        - Other (please describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command(s) run
+      description: The exact hostswitch command(s), and whether sudo was used.
+      placeholder: |
+        $ hostswitch switch production
+        (or: $ sudo hostswitch switch production)
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-json
+    attributes:
+      label: Contents of ~/.hostswitch/current.json
+      description: >
+        Only if it doesn't contain anything sensitive. This helps us tell
+        whether hostswitch's tracked state matches the real hosts file.
+      render: json
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output / error messages
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/milkmaccya2/hostswitch/security/advisories/new
+    about: Please report security issues privately rather than in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Suggest an idea or improvement for hostswitch
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case or limitation you're running into.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like hostswitch to do instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've thought about.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related Issue
+
+<!-- e.g. Closes #85 -->
+
+## Checklist
+
+- [ ] `npm run check` passes locally (lint + format + tests)
+- [ ] Tests added or updated for the change
+- [ ] Documentation updated (README, docs site, etc.) if behavior changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to HostSwitch
+
+Thanks for considering a contribution! This document covers the basics for
+human contributors. If you're an AI coding agent working in this repo, see
+[CLAUDE.md](CLAUDE.md) for more detailed architecture and workflow notes.
+
+Found a security issue instead? Please see [SECURITY.md](SECURITY.md) rather
+than opening a public issue or PR.
+
+## Getting Started
+
+```bash
+# Clone your fork
+git clone https://github.com/<you>/hostswitch.git
+cd hostswitch
+
+# Install dependencies
+npm install
+
+# Run the CLI directly against TypeScript source, without building
+npm run dev -- list
+
+# Or build once and run the compiled output
+npm run build
+npm start -- list
+```
+
+While iterating, `npm run build:watch` recompiles on save.
+
+## Development Flow
+
+1. Create a branch off `main` for your change.
+2. Write or update tests first where practical (see [Testing](#testing)).
+3. Make your change.
+4. Run `npm run check` before opening a PR — this runs linting, format
+   checking, and the full test suite, and is the same gate CI enforces.
+5. Open a PR using the provided template.
+
+## Testing
+
+The project follows t-wada-style TDD: write a failing test, make it pass
+with minimal code, then refactor with the test still green.
+
+- Core business logic (`ProfileManager`, `CurrentProfileManager`,
+  `BackupManager`, `HostSwitchService`) lives under `src/core/` and **must**
+  have unit test coverage in `src/core/__tests__/`.
+- All external dependencies (file system, logging, process execution) are
+  injected via interfaces, so core logic can be tested without touching the
+  real file system — use the mocks in `src/__mocks__/` rather than the real
+  `IFileSystem`/`IProcessManager` implementations.
+- Prefer testing individual managers directly over exercising the same
+  logic indirectly through `HostSwitchService`; reserve
+  `HostSwitchService` tests for integration/coordination scenarios.
+
+```bash
+npm test               # watch mode
+npm run test:run       # single run
+npm run test:coverage  # coverage report
+```
+
+## Code Style
+
+Formatting and linting are enforced by [Biome](https://biomejs.dev/):
+2-space indentation, single quotes, semicolons, 100-character line width.
+
+```bash
+npm run lint:fix   # auto-fix lint + formatting issues
+npm run format     # format only
+```
+
+## Manual Testing Warning
+
+`hostswitch switch` (and `use`) actually overwrite your system hosts file
+(`/etc/hosts` on macOS/Linux, `C:\Windows\System32\drivers\etc\hosts` on
+Windows) and require sudo/administrator privileges to do so.
+
+**Before manually testing `switch`, back up your current hosts file**, e.g.:
+
+```bash
+sudo cp /etc/hosts /etc/hosts.bak
+```
+
+hostswitch does create its own automatic backups under
+`~/.hostswitch/backups/`, but taking your own backup first is cheap
+insurance while you're testing changes to the switching logic itself.
+
+## Pull Requests
+
+- Keep PRs focused on a single change where possible.
+- Make sure `npm run check` passes.
+- Update relevant documentation (README, docs site under `website/`, etc.)
+  if behavior changes.

--- a/README.ja.md
+++ b/README.ja.md
@@ -343,3 +343,8 @@ MIT License - 詳細は[LICENSE](LICENSE)ファイルを参照してください
 ## 貢献
 
 バグ報告や機能追加のリクエストは[GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues)で受け付けています。
+開発環境のセットアップ手順やテスト方針は[CONTRIBUTING.md](CONTRIBUTING.md)（英語）を参照してください。
+
+## セキュリティ
+
+セキュリティ上の問題を見つけた場合は、公開Issueではなく[SECURITY.md](SECURITY.md)（英語）の手順に従って報告してください。

--- a/README.md
+++ b/README.md
@@ -321,3 +321,8 @@ MIT License - See [LICENSE](LICENSE) file for details.
 ## Contributing
 
 Bug reports and feature requests are welcome at [GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development workflow, and testing guidelines.
+
+## Security
+
+Found a security issue? Please see [SECURITY.md](SECURITY.md) for how to report it privately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+HostSwitch modifies the system hosts file and, on most platforms, needs to
+re-run itself with `sudo`/administrator privileges to do so. Because of that,
+we treat security reports for this project seriously and ask that they be
+reported privately rather than filed as public issues.
+
+## Supported Versions
+
+Only the latest version published on npm is supported with security fixes.
+Please make sure you can reproduce the issue on the latest release
+(`hostswitch --version`) before reporting.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities using
+[GitHub Private Vulnerability Reporting](https://github.com/milkmaccya2/hostswitch/security/advisories/new)
+rather than a public issue, pull request, or discussion.
+
+When reporting, please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, including OS, Node.js version, and hostswitch version
+- Whether the issue requires sudo/administrator privileges to trigger
+
+We aim to acknowledge new reports within **5 business days** and to provide
+a fix or mitigation plan within **30 days**, depending on severity and
+complexity. We'll keep you updated as we investigate.
+
+## Scope
+
+**In scope** — issues where hostswitch itself is the source of the risk:
+
+- A non-privileged user being able to escalate privileges through
+  hostswitch (e.g. abusing the sudo re-run flow, editor invocation, or
+  profile file handling)
+- hostswitch writing to, or reading from, unintended file paths while
+  running with elevated privileges
+- Profile name/content handling that allows path traversal, command
+  injection, or arbitrary file writes
+- Backup or checksum logic that could silently corrupt or lose the system
+  hosts file
+
+**Out of scope**:
+
+- The local user intentionally editing their own hosts file, profiles, or
+  hostswitch configuration — hostswitch is a tool the user runs with their
+  own privileges, and actions taken deliberately by that user against their
+  own machine are not a vulnerability in hostswitch
+- Social engineering or physical access attacks
+- Issues that require an already-compromised machine or an already-malicious
+  local actor with equal or greater privileges than hostswitch itself
+
+If you're unsure whether something is in scope, please report it anyway —
+we'd rather triage a borderline report than miss a real issue.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with private vulnerability reporting instructions, response SLA, and explicit in-scope/out-of-scope guidance (privilege escalation / unintended sudo writes are in scope; a user's own deliberate hosts edits are not)
- Add `CONTRIBUTING.md`: a human-oriented distillation of `CLAUDE.md`'s dev workflow (setup, `npm run check` before PR, t-wada TDD testing policy, Biome formatting) plus a warning to back up the hosts file before manually testing `switch`
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` (OS, Node version, hostswitch version, install method, command run, `current.json` contents), `feature_request.yml`, and `config.yml` (disables blank issues, links to private vulnerability reporting)
- Add `.github/pull_request_template.md`
- Link `SECURITY.md` / `CONTRIBUTING.md` from both `README.md` and `README.ja.md`

## Related Issue
Closes #85

Note: enabling **GitHub Private Vulnerability Reporting** itself (Settings → Security → Private vulnerability reporting) is a repo setting that needs to be toggled by a maintainer with admin access — it can't be done via this PR.

## Test plan
- [x] `npm run test:run` — 190/190 tests pass
- [x] `npm run build` — succeeds
- [x] `npm run lint` — no new errors introduced (pre-existing CRLF-related errors on `main` in `src/`, unrelated to this change, confirmed via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)