### PR TITLE
fix: path traversal, atomic hosts write, non-destructive permission check (redo of #89)

### DIFF
--- a/src/__mocks__/index.ts
+++ b/src/__mocks__/index.ts
@@ -62,6 +62,20 @@ export class MockFileSystem implements IFileSystem {
     this.files.set(dest, content);
   }
 
+  renameSync(src: string, dest: string): void {
+    this.recordCall('renameSync', src, dest);
+    if (this.throwOnNext) {
+      this.throwOnNext = false;
+      throw this.nextError;
+    }
+    const content = this.files.get(src);
+    if (content === undefined) {
+      throw new Error(`Source file not found: ${src}`);
+    }
+    this.files.set(dest, content);
+    this.files.delete(src);
+  }
+
   unlinkSync(path: string): void {
     this.recordCall('unlinkSync', path);
     if (this.throwOnNext) {

--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -1,4 +1,5 @@
 import type { HostSwitchService } from '../core/HostSwitchService';
+import { INVALID_PROFILE_NAME_MESSAGE } from '../core/ProfileManager';
 import type {
   ICommandResult,
   IPermissionChecker,
@@ -56,6 +57,11 @@ export class HostSwitchFacade {
   }
 
   async switchProfile(name: string): Promise<ICommandResult> {
+    const validation = this.validateProfileName(name);
+    if (!validation.success) {
+      return validation;
+    }
+
     try {
       if (!this.hostSwitchService.profileExists(name)) {
         return {
@@ -158,6 +164,11 @@ export class HostSwitchFacade {
   }
 
   async showProfile(name: string): Promise<ICommandResult> {
+    const validation = this.validateProfileName(name);
+    if (!validation.success) {
+      return validation;
+    }
+
     try {
       const result = this.hostSwitchService.getProfileContent(name);
       if (result.success) {
@@ -180,6 +191,11 @@ export class HostSwitchFacade {
   }
 
   async editProfile(name: string): Promise<ICommandResult> {
+    const validation = this.validateProfileName(name);
+    if (!validation.success) {
+      return validation;
+    }
+
     try {
       if (!this.hostSwitchService.profileExists(name)) {
         return {
@@ -219,21 +235,18 @@ export class HostSwitchFacade {
     return profiles.filter((p) => !p.isCurrent);
   }
 
+  /**
+   * inquirer の validate に渡せる形。判定そのものは core が持つ。
+   */
+  validateProfileNameInput(input: string): boolean | string {
+    if (!input || input.trim() === '') {
+      return 'Profile name cannot be empty';
+    }
+    return this.hostSwitchService.isValidProfileName(input) ? true : INVALID_PROFILE_NAME_MESSAGE;
+  }
+
   private validateProfileName(name: string): ICommandResult {
-    if (!name || name.trim() === '') {
-      return {
-        success: false,
-        message: 'Profile name cannot be empty',
-      };
-    }
-
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-      return {
-        success: false,
-        message: 'Invalid profile name. Use only letters, numbers, hyphens, and underscores',
-      };
-    }
-
-    return { success: true };
+    const result = this.validateProfileNameInput(name);
+    return typeof result === 'string' ? { success: false, message: result } : { success: true };
   }
 }

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -26,6 +26,7 @@ describe('HostSwitchFacade', () => {
     getCurrentProfile: ReturnType<typeof vi.fn>;
     getConfig: ReturnType<typeof vi.fn>;
     isProfileApplied: ReturnType<typeof vi.fn>;
+    isValidProfileName: ReturnType<typeof vi.fn>;
   };
   let _mockLogger: ILogger;
   let mockProcessManager: IProcessManager;
@@ -43,6 +44,7 @@ describe('HostSwitchFacade', () => {
       getCurrentProfile: vi.fn(),
       getConfig: vi.fn().mockReturnValue({ hostsPath: '/etc/hosts' }),
       isProfileApplied: vi.fn().mockReturnValue(true),
+      isValidProfileName: vi.fn((name: string) => /^[a-zA-Z0-9_-]+$/.test(name)),
     };
 
     _mockLogger = {

--- a/src/cli/ui/InteractiveUserInterface.ts
+++ b/src/cli/ui/InteractiveUserInterface.ts
@@ -203,13 +203,9 @@ export class InteractiveUserInterface implements IUserInterface {
   }
 
   private async handleCreateProfile(): Promise<void> {
-    const profileName = await this.promptInput('Enter profile name:', (input: string) => {
-      if (!input.trim()) return 'Profile name cannot be empty';
-      if (!/^[a-zA-Z0-9_-]+$/.test(input)) {
-        return 'Use only letters, numbers, hyphens, and underscores';
-      }
-      return true;
-    });
+    const profileName = await this.promptInput('Enter profile name:', (input: string) =>
+      this.facade.validateProfileNameInput(input)
+    );
 
     const fromCurrent = await this.promptConfirm('Copy current hosts file content?');
     const result = await this.facade.createProfile(profileName, fromCurrent);

--- a/src/core/BackupManager.ts
+++ b/src/core/BackupManager.ts
@@ -1,4 +1,5 @@
-import type { HostSwitchConfig, IFileSystem } from '../interfaces';
+import * as path from 'node:path';
+import type { BackupResult, HostSwitchConfig, IFileSystem } from '../interfaces';
 
 export class BackupManager {
   constructor(
@@ -6,14 +7,26 @@ export class BackupManager {
     private config: HostSwitchConfig
   ) {}
 
-  backupHosts(): string | undefined {
+  /**
+   * hostsファイルを退避する。
+   *
+   * hostsファイルが存在しない場合は「退避するものが無い」ので成功として扱い、
+   * 退避すべき内容があるのに失敗した場合だけ失敗を返す。呼び出し側はこれを
+   * 区別して、後者では切り替えを中断できる。
+   */
+  backupHosts(): BackupResult {
+    if (!this.fileSystem.existsSync(this.config.hostsPath)) {
+      return { success: true, skipped: true };
+    }
+
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const backupPath = `${this.config.backupDir}/hosts_${timestamp}`;
+    const backupPath = path.join(this.config.backupDir, `hosts_${timestamp}`);
+
     try {
       this.fileSystem.copySync(this.config.hostsPath, backupPath);
-      return backupPath;
-    } catch (_err) {
-      return undefined;
+      return { success: true, path: backupPath };
+    } catch (err) {
+      return { success: false, message: (err as Error).message };
     }
   }
 }

--- a/src/core/HostSwitchService.ts
+++ b/src/core/HostSwitchService.ts
@@ -34,6 +34,10 @@ export class HostSwitchService {
     this.fileSystem.ensureDirSync(this.config.backupDir);
   }
 
+  isValidProfileName(name: string): boolean {
+    return this.profileManager.isValidProfileName(name);
+  }
+
   getCurrentProfile(): string | null {
     return this.currentProfileManager.getCurrentProfile();
   }

--- a/src/core/HostSwitchService.ts
+++ b/src/core/HostSwitchService.ts
@@ -76,7 +76,15 @@ export class HostSwitchService {
     let backupPath: string | undefined;
 
     if (!currentProfile || isModified) {
-      backupPath = this.backupManager.backupHosts();
+      const backup = this.backupManager.backupHosts();
+      if (!backup.success) {
+        // バックアップは切り替え前の安全装置なので、取れないまま進めない
+        return {
+          success: false,
+          message: `Aborted: could not back up the current hosts file (${backup.message}).`,
+        };
+      }
+      backupPath = backup.path;
       if (isModified && currentProfile) {
         this.logger.warn('Current hosts file was modified outside of hostswitch.');
       }
@@ -84,7 +92,7 @@ export class HostSwitchService {
 
     try {
       const profilePath = this.profileManager.getProfilePath(name);
-      this.fileSystem.copySync(profilePath, this.config.hostsPath);
+      this.replaceHostsFile(profilePath);
       this.currentProfileManager.setCurrentProfile(name);
       return {
         success: true,
@@ -105,6 +113,29 @@ export class HostSwitchService {
           message: `Error switching profile: ${error.message}`,
         };
       }
+    }
+  }
+
+  /**
+   * hostsファイルを差し替える。
+   *
+   * 同じディレクトリに一時ファイルを作ってから rename で置き換える。
+   * rename は同一ファイルシステム内でアトミックなので、途中で失敗しても
+   * hostsファイルが中途半端な内容になることがない。
+   */
+  private replaceHostsFile(profilePath: string): void {
+    const tempPath = `${this.config.hostsPath}.hostswitch-${process.pid}`;
+
+    try {
+      this.fileSystem.copySync(profilePath, tempPath);
+      this.fileSystem.renameSync(tempPath, this.config.hostsPath);
+    } catch (err) {
+      try {
+        this.fileSystem.unlinkSync(tempPath);
+      } catch {
+        // 後始末の失敗で本来のエラーを隠さない
+      }
+      throw err;
     }
   }
 

--- a/src/core/ProfileManager.ts
+++ b/src/core/ProfileManager.ts
@@ -5,6 +5,8 @@ import type {
   ProfileInfo,
 } from '../interfaces';
 
+const PROFILE_EXT = '.hosts';
+
 export class ProfileManager {
   constructor(
     private fileSystem: IFileSystem,
@@ -14,8 +16,8 @@ export class ProfileManager {
   getProfiles(currentProfile: string | null): ProfileInfo[] {
     const profiles = this.fileSystem
       .readdirSync(this.config.profilesDir)
-      .filter((file) => file.endsWith('.hosts'))
-      .map((file) => file.replace('.hosts', ''));
+      .filter((file) => file.endsWith(PROFILE_EXT))
+      .map((file) => file.slice(0, -PROFILE_EXT.length));
 
     return profiles.map((name) => ({
       name,
@@ -123,7 +125,7 @@ export class ProfileManager {
   }
 
   getProfilePath(name: string): string {
-    return `${this.config.profilesDir}/${name}.hosts`;
+    return `${this.config.profilesDir}/${name}${PROFILE_EXT}`;
   }
 
   private getDefaultHostsContent(): string {

--- a/src/core/ProfileManager.ts
+++ b/src/core/ProfileManager.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import type {
   CreateProfileResult,
   HostSwitchConfig,
@@ -7,11 +8,32 @@ import type {
 
 const PROFILE_EXT = '.hosts';
 
+/**
+ * プロファイル名として許可する文字。ここがアプリ全体で唯一の定義。
+ * パス区切り文字とドットを弾くことで、プロファイルディレクトリ外への
+ * 参照を成立させない。
+ */
+const PROFILE_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export const INVALID_PROFILE_NAME_MESSAGE =
+  'Invalid profile name. Use only letters, numbers, hyphens, and underscores';
+
+export class InvalidProfileNameError extends Error {
+  constructor(name: string) {
+    super(`${INVALID_PROFILE_NAME_MESSAGE} (got '${name}').`);
+    this.name = 'InvalidProfileNameError';
+  }
+}
+
 export class ProfileManager {
   constructor(
     private fileSystem: IFileSystem,
     private config: HostSwitchConfig
   ) {}
+
+  isValidProfileName(name: string): boolean {
+    return typeof name === 'string' && PROFILE_NAME_PATTERN.test(name);
+  }
 
   getProfiles(currentProfile: string | null): ProfileInfo[] {
     const profiles = this.fileSystem
@@ -26,6 +48,10 @@ export class ProfileManager {
   }
 
   createProfile(name: string, fromCurrent: boolean = false): CreateProfileResult {
+    if (!this.isValidProfileName(name)) {
+      return { success: false, message: INVALID_PROFILE_NAME_MESSAGE };
+    }
+
     const profilePath = this.getProfilePath(name);
 
     if (this.fileSystem.existsSync(profilePath)) {
@@ -63,6 +89,10 @@ export class ProfileManager {
     name: string,
     currentProfile: string | null
   ): { success: boolean; message: string } {
+    if (!this.isValidProfileName(name)) {
+      return { success: false, message: INVALID_PROFILE_NAME_MESSAGE };
+    }
+
     const profilePath = this.getProfilePath(name);
 
     if (!this.fileSystem.existsSync(profilePath)) {
@@ -95,6 +125,10 @@ export class ProfileManager {
   }
 
   getProfileContent(name: string): { success: boolean; content?: string; message?: string } {
+    if (!this.isValidProfileName(name)) {
+      return { success: false, message: INVALID_PROFILE_NAME_MESSAGE };
+    }
+
     const profilePath = this.getProfilePath(name);
 
     if (!this.fileSystem.existsSync(profilePath)) {
@@ -120,12 +154,26 @@ export class ProfileManager {
   }
 
   profileExists(name: string): boolean {
-    const profilePath = this.getProfilePath(name);
-    return this.fileSystem.existsSync(profilePath);
+    if (!this.isValidProfileName(name)) {
+      return false;
+    }
+    return this.fileSystem.existsSync(this.getProfilePath(name));
   }
 
   getProfilePath(name: string): string {
-    return `${this.config.profilesDir}/${name}${PROFILE_EXT}`;
+    if (!this.isValidProfileName(name)) {
+      throw new InvalidProfileNameError(name);
+    }
+
+    const profilePath = path.join(this.config.profilesDir, `${name}${PROFILE_EXT}`);
+
+    // 名前の検証を通っていれば到達しないが、パス組み立てを変えた際に
+    // ディレクトリ外へ出ていないことをここでも確かめる
+    if (path.dirname(path.resolve(profilePath)) !== path.resolve(this.config.profilesDir)) {
+      throw new InvalidProfileNameError(name);
+    }
+
+    return profilePath;
   }
 
   private getDefaultHostsContent(): string {

--- a/src/core/__tests__/BackupManager.test.ts
+++ b/src/core/__tests__/BackupManager.test.ts
@@ -18,12 +18,10 @@ describe('BackupManager', () => {
 
       const result = backupManager.backupHosts();
 
-      expect(result).toBeDefined();
-      expect(result).toContain(mocks.config.backupDir);
-      expect(result).toContain('hosts_');
-
-      const backupContent = mocks.mockFileSystem.getFile(result!);
-      expect(backupContent).toBe(hostsContent);
+      expect(result.success).toBe(true);
+      expect(result.path).toContain(mocks.config.backupDir);
+      expect(result.path).toContain('hosts_');
+      expect(mocks.mockFileSystem.getFile(result.path!)).toBe(hostsContent);
     });
 
     it('タイムスタンプ付きのバックアップファイル名を生成', () => {
@@ -31,28 +29,29 @@ describe('BackupManager', () => {
 
       const result = backupManager.backupHosts();
 
-      expect(result).toBeDefined();
-      expect(result).toMatch(/hosts_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z/);
+      expect(result.path).toMatch(/hosts_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z/);
     });
 
-    it('hostsファイルが存在しない場合はundefinedを返す', () => {
+    it('hostsファイルが存在しない場合は skipped として成功を返す', () => {
       const result = backupManager.backupHosts();
 
-      expect(result).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(result.path).toBeUndefined();
     });
 
-    it('バックアップ作成に失敗した場合はundefinedを返す', () => {
+    it('退避すべき内容があるのに失敗した場合は success=false を返す', () => {
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content');
-
-      const error = new Error('Backup failed');
-      mocks.mockFileSystem.setThrowErrorOnNext(error);
+      mocks.mockFileSystem.setThrowErrorOnNext(new Error('Backup failed'));
 
       const result = backupManager.backupHosts();
 
-      expect(result).toBeUndefined();
+      expect(result.success).toBe(false);
+      expect(result.skipped).toBeUndefined();
+      expect(result.message).toContain('Backup failed');
     });
 
-    it('コピー処理で例外が発生してもundefinedを返す', () => {
+    it('コピー処理で例外が発生した場合も失敗理由を返す', () => {
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content');
 
       const originalCopySync = mocks.mockFileSystem.copySync;
@@ -62,23 +61,23 @@ describe('BackupManager', () => {
 
       const result = backupManager.backupHosts();
 
-      expect(result).toBeUndefined();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Copy failed');
 
       mocks.mockFileSystem.copySync = originalCopySync;
     });
 
-    it('複数回呼び出すとファイルを作成する', () => {
+    it('複数回呼び出すとそれぞれファイルを作成する', () => {
       const hostsContent = 'test content';
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, hostsContent);
 
       const backup1 = backupManager.backupHosts();
       const backup2 = backupManager.backupHosts();
 
-      expect(backup1).toBeDefined();
-      expect(backup2).toBeDefined();
-
-      expect(mocks.mockFileSystem.getFile(backup1!)).toBe(hostsContent);
-      expect(mocks.mockFileSystem.getFile(backup2!)).toBe(hostsContent);
+      expect(backup1.success).toBe(true);
+      expect(backup2.success).toBe(true);
+      expect(mocks.mockFileSystem.getFile(backup1.path!)).toBe(hostsContent);
+      expect(mocks.mockFileSystem.getFile(backup2.path!)).toBe(hostsContent);
     });
 
     it('バックアップディレクトリ内に正しくファイルが作成される', () => {
@@ -86,9 +85,8 @@ describe('BackupManager', () => {
 
       const result = backupManager.backupHosts();
 
-      expect(result).toBeDefined();
-      expect(result?.startsWith(mocks.config.backupDir)).toBe(true);
-      expect(mocks.mockFileSystem.existsSync(result!)).toBe(true);
+      expect(result.path?.startsWith(mocks.config.backupDir)).toBe(true);
+      expect(mocks.mockFileSystem.existsSync(result.path!)).toBe(true);
     });
   });
 });

--- a/src/core/__tests__/HostSwitchService.test.ts
+++ b/src/core/__tests__/HostSwitchService.test.ts
@@ -171,7 +171,7 @@ describe('HostSwitchService - 統合テスト', () => {
       mocks.mockFileSystem.copySync = originalCopySync;
     });
 
-    it('バックアップ失敗後もプロファイル切り替えは継続', async () => {
+    it('バックアップに失敗した場合は切り替えを中断しhostsを書き換えない', async () => {
       mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'dev content');
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'original content');
 
@@ -188,12 +188,37 @@ describe('HostSwitchService - 統合テスト', () => {
 
       const result = await service.switchProfile('dev');
 
-      // バックアップは失敗したが、切り替えは成功
-      expect(result.success).toBe(true);
-      expect(result.backupPath).toBeUndefined();
-      expect(service.getCurrentProfile()).toBe('dev');
+      // 退避できないまま hosts を触らない
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('could not back up');
+      expect(mocks.mockFileSystem.getFile(mocks.config.hostsPath)).toBe('original content');
+      expect(service.getCurrentProfile()).toBeNull();
 
       mocks.mockFileSystem.copySync = originalCopySync;
+    });
+
+    it('切り替え中に失敗してもhostsが中途半端な内容にならない', async () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'dev content');
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'original content');
+
+      // 一時ファイルからhostsへの rename で失敗させる
+      const originalRenameSync = mocks.mockFileSystem.renameSync;
+      mocks.mockFileSystem.renameSync = () => {
+        throw new Error('Rename failed');
+      };
+
+      const result = await service.switchProfile('dev');
+
+      expect(result.success).toBe(false);
+      expect(mocks.mockFileSystem.getFile(mocks.config.hostsPath)).toBe('original content');
+
+      // 一時ファイルを残さない
+      const leftovers = mocks.mockFileSystem
+        .getCalls('unlinkSync')
+        .map((call) => call.args[0] as string);
+      expect(leftovers.some((p) => p.includes('.hostswitch-'))).toBe(true);
+
+      mocks.mockFileSystem.renameSync = originalRenameSync;
     });
   });
 

--- a/src/core/__tests__/ProfileManager.name-validation.test.ts
+++ b/src/core/__tests__/ProfileManager.name-validation.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InvalidProfileNameError, ProfileManager } from '../ProfileManager';
+import { createTestMocks } from './setup';
+
+/**
+ * プロファイル名はファイルパスの組み立てに使われるため、
+ * プロファイルディレクトリの外へ出られないことを名前を受け取る全ての
+ * 入口で確かめる。
+ */
+describe('ProfileManager - プロファイル名の検証', () => {
+  let profileManager: ProfileManager;
+  let mocks: ReturnType<typeof createTestMocks>;
+
+  const traversalNames = [
+    '../../../../tmp/evil',
+    '../outside',
+    'nested/name',
+    'name/../../escape',
+    '..',
+    '.',
+    'with space',
+    'semi;colon',
+    '$(whoami)',
+    '',
+  ];
+
+  beforeEach(() => {
+    mocks = createTestMocks();
+    profileManager = new ProfileManager(mocks.mockFileSystem, mocks.config);
+  });
+
+  describe('isValidProfileName()', () => {
+    it.each(traversalNames)('不正な名前 %j を拒否する', (name) => {
+      expect(profileManager.isValidProfileName(name)).toBe(false);
+    });
+
+    it.each(['dev', 'staging-1', 'my_profile', 'A1'])('正当な名前 %j を許可する', (name) => {
+      expect(profileManager.isValidProfileName(name)).toBe(true);
+    });
+  });
+
+  describe('getProfilePath()', () => {
+    it.each(traversalNames)('不正な名前 %j では例外を投げる', (name) => {
+      expect(() => profileManager.getProfilePath(name)).toThrow(InvalidProfileNameError);
+    });
+
+    it('正当な名前はプロファイルディレクトリ配下を指す', () => {
+      const result = profileManager.getProfilePath('dev');
+      expect(result).toBe(`${mocks.config.profilesDir}/dev.hosts`);
+    });
+  });
+
+  describe('名前を受け取る各メソッド', () => {
+    it.each(traversalNames)('profileExists(%j) は false を返す', (name) => {
+      expect(profileManager.profileExists(name)).toBe(false);
+    });
+
+    it.each(traversalNames)('createProfile(%j) は失敗する', (name) => {
+      const result = profileManager.createProfile(name);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Invalid profile name');
+    });
+
+    it.each(traversalNames)('deleteProfile(%j) は失敗する', (name) => {
+      const result = profileManager.deleteProfile(name, null);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Invalid profile name');
+    });
+
+    it.each(traversalNames)('getProfileContent(%j) は失敗する', (name) => {
+      const result = profileManager.getProfileContent(name);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Invalid profile name');
+    });
+  });
+
+  it('ディレクトリ外のファイルが存在していても読み出せない', () => {
+    mocks.mockFileSystem.setFile('/tmp/evil.hosts', '127.0.0.1 attacker.example');
+
+    const result = profileManager.getProfileContent('../../../../tmp/evil');
+
+    expect(result.success).toBe(false);
+    expect(result.content).toBeUndefined();
+  });
+});

--- a/src/core/__tests__/ProfileManager.test.ts
+++ b/src/core/__tests__/ProfileManager.test.ts
@@ -42,6 +42,15 @@ describe('ProfileManager', () => {
       expect(stagingProfile?.isCurrent).toBe(false);
     });
 
+    it('名前の途中に.hostsを含むファイルでも末尾の拡張子だけを除去する', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/my.hosts.local.hosts`, 'content');
+
+      const result = profileManager.getProfiles(null);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('my.hosts.local');
+    });
+
     it('.hostsファイル以外は無視される', () => {
       mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'content');
       mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/readme.txt`, 'readme');

--- a/src/infrastructure/FileSystemAdapter.ts
+++ b/src/infrastructure/FileSystemAdapter.ts
@@ -22,6 +22,10 @@ export class FileSystemAdapter implements IFileSystem {
     fs.copySync(src, dest);
   }
 
+  renameSync(src: string, dest: string): void {
+    fs.renameSync(src, dest);
+  }
+
   unlinkSync(path: string): void {
     fs.unlinkSync(path);
   }

--- a/src/infrastructure/PermissionChecker.ts
+++ b/src/infrastructure/PermissionChecker.ts
@@ -3,24 +3,12 @@ import * as fs from 'fs-extra';
 import type { IPermissionChecker, SudoResult } from '../interfaces';
 
 export class PermissionChecker implements IPermissionChecker {
+  /**
+   * 書き込み可否を問い合わせるだけで、対象ファイルには一切触れない。
+   */
   async canWriteToFile(filePath: string): Promise<boolean> {
     try {
-      // copySync操作に必要な権限をテストする
-      // 一時的なバックアップファイルでcopySync操作をシミュレート
-      const tempPath = `${filePath}.hostswitch-test`;
-
-      // 元ファイルの内容を読み取り
-      const originalContent = await fs.readFile(filePath, 'utf8');
-
-      // 一時ファイルに書き込み
-      await fs.writeFile(tempPath, originalContent);
-
-      // copySync操作をテスト（実際にunlink/copyを実行）
-      await fs.copy(tempPath, filePath, { overwrite: true });
-
-      // テスト用一時ファイルを削除
-      await fs.unlink(tempPath);
-
+      await fs.access(filePath, fs.constants.W_OK);
       return true;
     } catch (_error) {
       // EACCES (Permission denied) またはその他のエラーの場合はfalse
@@ -28,13 +16,22 @@ export class PermissionChecker implements IPermissionChecker {
     }
   }
 
-  requiresSudo(_filePath?: string): boolean {
-    // sudoで実行中の場合は不要
+  requiresSudo(filePath?: string): boolean {
+    // rootで実行中なら昇格は不要
     if (this.isRunningAsSudo()) {
       return false;
     }
 
-    // デフォルトでhostsファイルへの書き込みはsudoが必要
+    // 対象が分かっていて、かつ既に書けるなら昇格を求めない
+    if (filePath) {
+      try {
+        fs.accessSync(filePath, fs.constants.W_OK);
+        return false;
+      } catch (_error) {
+        return true;
+      }
+    }
+
     return true;
   }
 
@@ -44,8 +41,10 @@ export class PermissionChecker implements IPermissionChecker {
   }
 
   isRunningAsSudo(): boolean {
-    // process.getuid()が0（root）の場合、またはSUDO_USER環境変数が設定されている場合
-    return process.getuid?.() === 0 || process.env.SUDO_USER !== undefined;
+    // 実効ユーザIDだけで判定する。SUDO_USER は `sudo -s` 後のシェルから
+    // 起動した非特権プロセスにも引き継がれるため、昇格済みの証拠にならない。
+    const euid = process.geteuid?.() ?? process.getuid?.();
+    return euid === 0;
   }
 
   async rerunWithSudo(args: string[]): Promise<SudoResult> {

--- a/src/infrastructure/__tests__/PermissionChecker.test.ts
+++ b/src/infrastructure/__tests__/PermissionChecker.test.ts
@@ -5,6 +5,7 @@ import { PermissionChecker } from '../PermissionChecker';
 vi.mock('child_process');
 vi.mock('fs-extra', () => ({
   access: vi.fn(),
+  accessSync: vi.fn(),
   readFile: vi.fn(),
   writeFile: vi.fn(),
   copy: vi.fn(),
@@ -35,119 +36,105 @@ describe('PermissionChecker', () => {
   });
 
   describe('canWriteToFile()', () => {
-    it('copySync操作が成功する場合はtrueを返す', async () => {
-      // 全ての操作が成功するようにモック設定
-      mockFs.readFile.mockResolvedValue('test content');
-      mockFs.writeFile.mockResolvedValue(undefined);
-      mockFs.copy.mockResolvedValue(undefined);
-      mockFs.unlink.mockResolvedValue(undefined);
+    it('書き込み可能な場合はtrueを返す', async () => {
+      mockFs.access.mockResolvedValue(undefined);
 
       const result = await permissionChecker.canWriteToFile('/test/file');
 
       expect(result).toBe(true);
-      expect(mockFs.readFile).toHaveBeenCalledWith('/test/file', 'utf8');
-      expect(mockFs.writeFile).toHaveBeenCalledWith('/test/file.hostswitch-test', 'test content');
-      expect(mockFs.copy).toHaveBeenCalledWith('/test/file.hostswitch-test', '/test/file', {
-        overwrite: true,
-      });
-      expect(mockFs.unlink).toHaveBeenCalledWith('/test/file.hostswitch-test');
+      expect(mockFs.access).toHaveBeenCalledWith('/test/file', mockFs.constants.W_OK);
     });
 
-    it('copySync操作でEACCESエラーが発生した場合はfalseを返す', async () => {
-      mockFs.readFile.mockResolvedValue('test content');
-      mockFs.writeFile.mockResolvedValue(undefined);
-      mockFs.copy.mockRejectedValue(
-        Object.assign(new Error('Permission denied'), { code: 'EACCES' })
-      );
+    it('書き込み不可の場合はfalseを返す', async () => {
+      mockFs.access.mockRejectedValue(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
 
       const result = await permissionChecker.canWriteToFile('/test/file');
 
       expect(result).toBe(false);
     });
 
-    it('readFileでエラーが発生した場合はfalseを返す', async () => {
-      mockFs.readFile.mockRejectedValue(new Error('File not found'));
+    it('対象ファイルへの書き込みを一切行わない', async () => {
+      mockFs.access.mockResolvedValue(undefined);
 
-      const result = await permissionChecker.canWriteToFile('/test/file');
+      await permissionChecker.canWriteToFile('/etc/hosts');
 
-      expect(result).toBe(false);
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockFs.copy).not.toHaveBeenCalled();
+      expect(mockFs.unlink).not.toHaveBeenCalled();
     });
   });
 
   describe('requiresSudo()', () => {
-    it('sudoで実行中の場合は書き込み権限に関係なくfalseを返す', () => {
-      // process.getuid()をモック（root権限をシミュレート）
-      const originalGetuid = process.getuid;
-      process.getuid = vi.fn().mockReturnValue(0);
+    const withEuid = (uid: number, fn: () => void) => {
+      const original = process.geteuid;
+      process.geteuid = () => uid;
+      try {
+        fn();
+      } finally {
+        process.geteuid = original;
+      }
+    };
 
-      const result = permissionChecker.requiresSudo('/etc/hosts');
-
-      expect(result).toBe(false);
-
-      // 復元
-      process.getuid = originalGetuid;
+    it('root実行中は書き込み権限に関係なくfalseを返す', () => {
+      withEuid(0, () => {
+        expect(permissionChecker.requiresSudo('/etc/hosts')).toBe(false);
+      });
     });
 
-    it('書き込み権限がある場合はfalseを返す', () => {
-      // 新しい実装では、sudo権限がない限り常にtrueを返すように変更
-      const result = permissionChecker.requiresSudo('/test/file');
-
-      expect(result).toBe(true);
+    it('非rootでも対象に書き込めるならfalseを返す', () => {
+      mockFs.accessSync.mockReturnValue(undefined);
+      withEuid(1000, () => {
+        expect(permissionChecker.requiresSudo('/etc/hosts')).toBe(false);
+      });
     });
 
-    it('書き込み権限がない場合はtrueを返す', () => {
-      // 新しい実装では、sudo権限がない限り常にtrueを返す
-      const result = permissionChecker.requiresSudo('/etc/hosts');
+    it('非rootで書き込めない場合はtrueを返す', () => {
+      mockFs.accessSync.mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+      withEuid(1000, () => {
+        expect(permissionChecker.requiresSudo('/etc/hosts')).toBe(true);
+      });
+    });
 
-      expect(result).toBe(true);
+    it('対象が指定されていない場合は非rootならtrueを返す', () => {
+      withEuid(1000, () => {
+        expect(permissionChecker.requiresSudo()).toBe(true);
+      });
     });
   });
 
   describe('isRunningAsSudo()', () => {
-    it('process.getuidが0の場合はtrueを返す', () => {
-      const originalGetuid = process.getuid;
-      process.getuid = vi.fn().mockReturnValue(0);
+    const withEuid = (uid: number, fn: () => void) => {
+      const original = process.geteuid;
+      process.geteuid = () => uid;
+      try {
+        fn();
+      } finally {
+        process.geteuid = original;
+      }
+    };
 
-      const result = permissionChecker.isRunningAsSudo();
-
-      expect(result).toBe(true);
-
-      // 復元
-      process.getuid = originalGetuid;
+    it('実効UIDが0の場合はtrueを返す', () => {
+      withEuid(0, () => {
+        expect(permissionChecker.isRunningAsSudo()).toBe(true);
+      });
     });
 
-    it('SUDO_USER環境変数が設定されている場合はtrueを返す', () => {
+    it('SUDO_USERだけが設定されていてもfalseを返す', () => {
+      // `sudo -s` 後のシェルから起動した非特権プロセスにも SUDO_USER は
+      // 引き継がれるため、昇格済みの証拠として使ってはいけない
       process.env.SUDO_USER = 'testuser';
-
-      const result = permissionChecker.isRunningAsSudo();
-
-      expect(result).toBe(true);
+      withEuid(1000, () => {
+        expect(permissionChecker.isRunningAsSudo()).toBe(false);
+      });
     });
 
-    it('どちらの条件も満たさない場合はfalseを返す', () => {
-      const originalGetuid = process.getuid;
-      process.getuid = vi.fn().mockReturnValue(1000);
+    it('非rootかつSUDO_USERなしの場合はfalseを返す', () => {
       delete process.env.SUDO_USER;
-
-      const result = permissionChecker.isRunningAsSudo();
-
-      expect(result).toBe(false);
-
-      // 復元
-      process.getuid = originalGetuid;
-    });
-
-    it('process.getuidが利用できない環境ではSUDO_USER環境変数のみで判定', () => {
-      const originalGetuid = process.getuid;
-      delete (process as NodeJS.Process).getuid;
-      delete process.env.SUDO_USER;
-
-      const result = permissionChecker.isRunningAsSudo();
-
-      expect(result).toBe(false);
-
-      // 復元
-      process.getuid = originalGetuid;
+      withEuid(1000, () => {
+        expect(permissionChecker.isRunningAsSudo()).toBe(false);
+      });
     });
   });
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -10,6 +10,7 @@ export interface IFileSystem {
   readFileSync(path: string): string;
   writeFileSync(path: string, content: string): void;
   copySync(src: string, dest: string): void;
+  renameSync(src: string, dest: string): void;
   unlinkSync(path: string): void;
   existsSync(path: string): boolean;
   ensureDirSync(path: string): void;
@@ -60,6 +61,15 @@ export interface SwitchResult {
   message?: string;
   backupPath?: string;
   requiresSudo?: boolean;
+}
+
+export interface BackupResult {
+  success: boolean;
+  /** 退避先。skipped の場合は無い */
+  path?: string;
+  /** hostsファイルが存在せず、退避するものが無かった */
+  skipped?: boolean;
+  message?: string;
 }
 
 export interface CreateProfileResult {


### PR DESCRIPTION
#89 の作り直しです。#89 は古い `main`（66コミット遅れ）から分岐していたため draft に戻し、こちらを最新の `main` に対して作り直しました。

**1コミット = 1 Issue** で、後のコミットが前に乗る順に積んであります。**コミット単位で上から順に読むのが一番速い**です。

## レビュー順

| # | コミット | Issue | 規模 | 読みどころ |
|---|---|---|---|---|
| 1 | `strip only the trailing .hosts extension` | #77 | 1行 | 準備運動。`replace` → `slice` |
| 2 | `replace hosts atomically and stop switching when backup fails` | #73 | **中・要レビュー** | hosts の書き込み経路が変わる。挙動変更あり |
| 3 | `enforce profile name validation in the core layer` | #71 | **中・要レビュー** | 検証を core に集約。パストラバーサルを塞ぐ |
| 4 | `make the permission check non-destructive and trust only euid` | #72（一部） | 中 | 破壊的プローブの除去。消す方が主 |

**2 と 3 に時間を使ってください。**

## 挙動が変わるところ（意図的）

**バックアップに失敗したら切り替えを中断する**（#73）。従来はバックアップ失敗が黙って無視され、退避なしで `/etc/hosts` が上書きされていました。「切り替え前に必ず退避」という安全装置が、一番効いてほしい場面で外れる状態だったので、中断side に倒しています。`/etc/hosts` がまだ存在しない場合は「退避するものが無い」として成功扱いで通します。

## テストを書き換えている箇所（要確認）

旧挙動を固定していた既存テストを、逆の期待に置き換えています。**差分をそのまま信じずに意図を確認してもらえると助かります。**

- `HostSwitchService.test.ts` の「バックアップ失敗後もプロファイル切り替えは継続」→「バックアップに失敗した場合は切り替えを中断しhostsを書き換えない」
- `PermissionChecker.test.ts` の `canWriteToFile` / `isRunningAsSudo` 系を、破壊的プローブと `SUDO_USER` 判定の前提から新仕様に差し替え

## #89 から落としたもの

`main` が進んでいて既に解決済みだったため、以下2件は含めていません。対応する Issue も close 済みです。

- **#70**（`$EDITOR` / `execSync`）→ #65 と #69 で対応済み
- **#79**（`isActive` フラグ）→ 既に `isCurrent` に統一済み

#72 のうち sudo 再実行まわり（引数配列での spawn、npm 判定の除去）も #63 / #66 で既に対応済みだったため、今回は破壊的プローブと euid 判定のみに絞っています。**#72 は完全には閉じないので open のままにしてあります。**

## 手元での確認

```
$ hostswitch show '../../../../etc/hosts'
Error: Invalid profile name. Use only letters, numbers, hyphens, and underscores

$ sudo hostswitch switch '../../../../tmp/evil'
Error: Invalid profile name. Use only letters, numbers, hyphens, and underscores
```

`npm run check`（lint + format + test）通過。テストは **258件**。

Closes #71, closes #73, closes #77
Refs #72, refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
