### PR TITLE
docs: add OSS community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a bug so it can be reproduced and fixed.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report this.
+  - type: input
+    id: os
+    attributes:
+      label: Operating system and version
+      description: Include the OS and version, since the hosts path and elevation flow are OS-dependent.
+      placeholder: "macOS 14.5 / Ubuntu 24.04 / Windows 11"
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Node.js and HostSwitch versions
+      description: Run `node --version` and `hostswitch --version`.
+      placeholder: "Node.js 22.14.0 / hostswitch 1.2.13"
+    validations:
+      required: true
+  - type: input
+    id: install
+    attributes:
+      label: Installation method
+      description: npm global install, npm link, or source.
+      placeholder: "npm install -g"
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and sudo context
+      description: Paste the exact command and whether it ran with or without sudo/admin.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: state
+    attributes:
+      label: Current profile state (optional)
+      description: If safe to share, paste `~/.hostswitch/current.json` with sensitive values removed.
+      render: json
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security policy
+    url: https://github.com/milkmaccya2/hostswitch/security/policy
+    about: Please report vulnerabilities through GitHub Private Vulnerability Reporting.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an improvement or new feature.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for sharing your idea.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What does not work well today, or what would this feature make easier?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or command you would expect.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, use cases, or links are welcome.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Related issue
+
+Closes #...
+
+## Checklist
+
+- [ ] `npm run check` passes
+- [ ] Tests added or updated for behavior changes
+- [ ] Documentation updated in `README.md` or `README.ja.md` when user-facing behavior changed
+- [ ] Commits signed with DCO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to HostSwitch
+
+Thanks for contributing. This guide covers setup, quality checks, tests, and the PR workflow.
+
+## Getting started
+
+Prerequisites:
+
+- Node.js 20 or newer
+- npm
+
+```bash
+git clone https://github.com/milkmaccya2/hostswitch.git
+cd hostswitch
+npm install
+```
+
+## Development flow
+
+```bash
+npm run build              # Compile TypeScript
+npm run dev -- list        # Run the CLI from source
+npm run build:watch        # Rebuild on changes
+```
+
+Before opening a PR, run the full quality gate:
+
+```bash
+npm run check
+```
+
+`npm run check` runs Biome lint, Biome format check, and the Vitest suite once.
+
+## Code style
+
+HostSwitch uses Biome with these rules:
+
+- 2 spaces indentation
+- Single quotes
+- Semicolons always
+- 100 character line width
+- Alphabetical imports with explicit type imports
+- Node.js protocol for built-in modules (`node:fs`)
+
+Use `npm run lint:fix` to auto-fix formatting and lint issues.
+
+## Tests
+
+- Unit tests live next to the source in `__tests__` directories.
+- The project follows t-wada TDD: write a failing test first, then make it pass, then refactor.
+- Core layers should have focused unit tests instead of testing everything through one service.
+- External dependencies are abstracted through interfaces so tests do not touch the real filesystem.
+
+Commands:
+
+```bash
+npm run test:run          # Run tests once
+npm run test:coverage     # Run tests with coverage
+npm run test:ui           # Open the Vitest UI
+```
+
+## Manual testing
+
+`hostswitch switch` and `hostswitch use` modify the real system hosts file with sudo/admin. Before manual testing:
+
+1. Back up `/etc/hosts` (or the Windows hosts file).
+2. Verify the current profile with `hostswitch show`.
+3. Switch back after the test and check `hostswitch list`.
+
+Never add a test that modifies the real hosts file.
+
+## Pull requests
+
+- Keep changes focused and reference the related issue.
+- Add or update tests for behavior changes.
+- Run `npm run check` before pushing.
+- Update `README.md` or `README.ja.md` when user-facing behavior changes.
+- Sign commits with `git commit -s` for DCO.
+- Reply to review comments in the PR and update the branch when needed.
+
+## Security
+
+Do not report vulnerabilities in public issues. See [SECURITY.md](SECURITY.md) and use GitHub Private Vulnerability Reporting.

--- a/README.ja.md
+++ b/README.ja.md
@@ -342,4 +342,8 @@ MIT License - 詳細は[LICENSE](LICENSE)ファイルを参照してください
 
 ## 貢献
 
-バグ報告や機能追加のリクエストは[GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues)で受け付けています。
+セットアップ、テスト、コードスタイル、PRの流れは[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。バグ報告や機能追加のリクエストは[GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues)で受け付けています。
+
+## セキュリティ
+
+サポート対象バージョンと脆弱性の報告方法は[SECURITY.md](SECURITY.md)を参照してください。GitHub Private Vulnerability Reportingを利用してください。

--- a/README.md
+++ b/README.md
@@ -320,4 +320,8 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 ## Contributing
 
-Bug reports and feature requests are welcome at [GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, tests, code style, and the PR workflow. Bug reports and feature requests are welcome at [GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for supported versions and how to report vulnerabilities through GitHub Private Vulnerability Reporting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+HostSwitch modifies the system hosts file, so security reports are handled with priority.
+
+## Supported versions
+
+Only the latest published version is supported. Please upgrade before reporting a vulnerability.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a security vulnerability. Use **GitHub Private Vulnerability Reporting** on this repository:
+
+https://github.com/milkmaccya2/hostswitch/security/policy
+
+If Private Vulnerability Reporting is not enabled yet, ask a maintainer to enable it in **Settings -> Security -> Private vulnerability reporting**.
+
+Please include:
+
+- HostSwitch version (`hostswitch --version`)
+- Operating system and version
+- Installation method (npm global, npm link, or source)
+- The command that triggered the issue and whether sudo/admin was used
+- A minimal reproduction when possible
+- Impact and any suggested mitigation
+
+## Scope
+
+In scope:
+
+- Privilege escalation through HostSwitch by an unprivileged user
+- Unexpected file writes as root/sudo caused by HostSwitch
+- Command injection, path traversal, or unsafe handling of profile data
+- Issues in the auto-sudo or permission-checking flow
+
+Out of scope:
+
+- A local user intentionally using HostSwitch with their own privileges
+- Security issues in third-party dependencies that have already been fixed upstream
+
+## Response
+
+The maintainers aim to acknowledge reports within 3 business days and will coordinate disclosure through GitHub's private reporting workflow.


### PR DESCRIPTION
Closes #85

## Summary

Adds the missing community health files:

- `SECURITY.md` with supported versions, reporting path, scope, and response expectations
- `CONTRIBUTING.md` with setup, development commands, code style, tests, manual sudo testing precautions, and PR workflow
- Bug report and feature request issue templates
- PR template with a quality checklist
- Links from `README.md` and `README.ja.md`

## Verification

- YAML issue templates parse successfully.
- `git diff --check` passes.
- Docs-only change; no source files are modified.

Note: GitHub Private Vulnerability Reporting must be enabled in repository settings for the `SECURITY.md` reporting path to work.

Signed off with DCO.