### PR TITLE
fix: check for updates at most daily, and never as root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,14 @@ Build commands:
 
 ## Update Notification Feature
 
-HostSwitch checks for a newer published version with `update-notifier`, called directly from `main()` in `src/hostswitch.ts`:
-- **Check**: Runs in a detached child process, so it never blocks an operation. `updateCheckInterval: 0` starts a check on every invocation
+HostSwitch checks for a newer published version with `update-notifier`, wrapped by the
+`UpdateChecker` class in `src/core/UpdateChecker.ts` and called from `main()` in `src/hostswitch.ts`:
+- **Check**: Runs in a detached child process, so it never blocks an operation. `updateCheckInterval`
+  is 24 hours, so a check starts at most once a day rather than on every invocation
+- **Skipped entirely when**: `HOSTSWITCH_NO_UPDATE_CHECK=true`, or the process is running as root.
+  The root case matters because `switch` re-runs itself under sudo — letting `update-notifier` write
+  its config store as root would make later non-sudo runs fail with `EACCES`. `UpdateChecker.skipReason()`
+  reports which of the two applied
 - **Notification timing**: The check writes its result to a config store and the notifier reads that result on the *next* invocation, printing it when the process exits. A version published moments ago is reported one run later
 - **Requires a TTY**: Nothing is printed when stdout is not a TTY, so piping the output hides the notice
 - **Disabled when**: `NO_UPDATE_NOTIFIER` is present in the environment, `NODE_ENV=test`, `--no-update-notifier` is passed, or a CI environment is detected

--- a/README.ja.md
+++ b/README.ja.md
@@ -346,6 +346,16 @@ MIT License - 詳細は[LICENSE](LICENSE)ファイルを参照してください
 バグ報告や機能追加のリクエストは[GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues)で受け付けています。
 開発環境のセットアップ手順やテスト方針は[CONTRIBUTING.md](CONTRIBUTING.md)（英語）を参照してください。
 
+## 更新通知
+
+新しいバージョンの確認は1日1回までです。無効にするには:
+
+```bash
+export HOSTSWITCH_NO_UPDATE_CHECK=true
+```
+
+root実行中は自動的にスキップされるので、`sudo hostswitch switch` がroot所有の設定ファイルを残すことはありません。
+
 ## セキュリティ
 
 セキュリティ上の問題を見つけた場合は、公開Issueではなく[SECURITY.md](SECURITY.md)（英語）の手順に従って報告してください。

--- a/README.md
+++ b/README.md
@@ -324,6 +324,17 @@ MIT License - See [LICENSE](LICENSE) file for details.
 Bug reports and feature requests are welcome at [GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues).
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development workflow, and testing guidelines.
 
+## Update Notifications
+
+hostswitch checks for a newer published version at most once a day. To turn it off:
+
+```bash
+export HOSTSWITCH_NO_UPDATE_CHECK=true
+```
+
+The check is also skipped automatically while running as root, so `sudo hostswitch switch` never
+leaves a root-owned config file behind.
+
 ## Security
 
 Found a security issue? Please see [SECURITY.md](SECURITY.md) for how to report it privately.

--- a/src/core/UpdateChecker.ts
+++ b/src/core/UpdateChecker.ts
@@ -1,0 +1,71 @@
+import updateNotifier from 'update-notifier';
+
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+
+/** 更新チェックを行わない理由。行う場合は null */
+export type SkipReason = 'opted-out' | 'running-as-root' | null;
+
+export interface UpdateCheckerDeps {
+  env?: NodeJS.ProcessEnv;
+  /** 実効ユーザID。取得できない環境（Windows）では undefined */
+  getEuid?: () => number | undefined;
+  notifier?: typeof updateNotifier;
+}
+
+export interface UpdateCheckerPackage {
+  name: string;
+  version: string;
+}
+
+export class UpdateChecker {
+  private env: NodeJS.ProcessEnv;
+  private getEuid: () => number | undefined;
+  private notifier: typeof updateNotifier;
+
+  constructor(
+    private pkg: UpdateCheckerPackage,
+    deps: UpdateCheckerDeps = {}
+  ) {
+    this.env = deps.env ?? process.env;
+    this.getEuid = deps.getEuid ?? (() => process.geteuid?.() ?? process.getuid?.());
+    this.notifier = deps.notifier ?? updateNotifier;
+  }
+
+  /**
+   * チェックを見送る理由を返す。行う場合は null。
+   *
+   * root で実行中に見送るのは、update-notifier が configstore を
+   * root 所有で作ってしまい、以降の非 sudo 実行が EACCES で
+   * 失敗するようになるため。switch は sudo で再実行されるので
+   * この経路は普通に踏まれる。
+   */
+  skipReason(): SkipReason {
+    if (this.env.HOSTSWITCH_NO_UPDATE_CHECK === 'true') {
+      return 'opted-out';
+    }
+    if (this.getEuid() === 0) {
+      return 'running-as-root';
+    }
+    return null;
+  }
+
+  /**
+   * 更新があれば通知する。ネットワークアクセスは update-notifier が
+   * バックグラウンドで行うため、ここでは待たない。
+   */
+  check(message: string): SkipReason {
+    const reason = this.skipReason();
+    if (reason !== null) {
+      return reason;
+    }
+
+    this.notifier({
+      pkg: this.pkg,
+      // 既定と同じ24時間。0 にすると毎回ネットワークアクセスが発生する
+      updateCheckInterval: ONE_DAY_MS,
+      shouldNotifyInNpmScript: true,
+    }).notify({ isGlobal: true, message });
+
+    return null;
+  }
+}

--- a/src/core/__tests__/UpdateChecker.test.ts
+++ b/src/core/__tests__/UpdateChecker.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { UpdateCheckerDeps } from '../UpdateChecker';
+import { UpdateChecker } from '../UpdateChecker';
+
+const pkg = { name: 'hostswitch', version: '1.2.13' };
+
+/** update-notifier の呼び出しを記録するだけのスタブ */
+function createChecker(opts: { env?: NodeJS.ProcessEnv; euid?: number | undefined } = {}) {
+  const notify = vi.fn();
+  const notifier = vi.fn(() => ({ notify }));
+  const checker = new UpdateChecker(pkg, {
+    env: opts.env ?? {},
+    getEuid: () => opts.euid,
+    notifier: notifier as unknown as UpdateCheckerDeps['notifier'],
+  });
+  return { checker, notifier, notify };
+}
+
+describe('UpdateChecker', () => {
+  describe('skipReason()', () => {
+    it('通常は null（チェックする）', () => {
+      const { checker } = createChecker({ euid: 501 });
+      expect(checker.skipReason()).toBeNull();
+    });
+
+    it('HOSTSWITCH_NO_UPDATE_CHECK=true なら見送る', () => {
+      const { checker } = createChecker({
+        env: { HOSTSWITCH_NO_UPDATE_CHECK: 'true' },
+        euid: 501,
+      });
+      expect(checker.skipReason()).toBe('opted-out');
+    });
+
+    it('true 以外の値では見送らない', () => {
+      const { checker } = createChecker({
+        env: { HOSTSWITCH_NO_UPDATE_CHECK: '1' },
+        euid: 501,
+      });
+      expect(checker.skipReason()).toBeNull();
+    });
+
+    it('root 実行中は見送る', () => {
+      // sudo 実行時に configstore が root 所有で作られると、
+      // 以降の非 sudo 実行が EACCES で落ちるため
+      const { checker } = createChecker({ euid: 0 });
+      expect(checker.skipReason()).toBe('running-as-root');
+    });
+
+    it('euid を取得できない環境（Windows）ではチェックする', () => {
+      const { checker } = createChecker({ euid: undefined });
+      expect(checker.skipReason()).toBeNull();
+    });
+  });
+
+  describe('check()', () => {
+    it('チェック時は24時間間隔を指定する', () => {
+      const { checker, notifier, notify } = createChecker({ euid: 501 });
+
+      const reason = checker.check('msg');
+
+      expect(reason).toBeNull();
+      expect(notifier).toHaveBeenCalledWith(
+        expect.objectContaining({ pkg, updateCheckInterval: 1000 * 60 * 60 * 24 })
+      );
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'msg' }));
+    });
+
+    it('毎回チェックする設定（interval 0）にはしない', () => {
+      const { checker, notifier } = createChecker({ euid: 501 });
+
+      checker.check('msg');
+
+      const arg = notifier.mock.calls[0][0] as { updateCheckInterval: number };
+      expect(arg.updateCheckInterval).toBeGreaterThan(0);
+    });
+
+    it('オプトアウト時は update-notifier を呼ばない', () => {
+      const { checker, notifier } = createChecker({
+        env: { HOSTSWITCH_NO_UPDATE_CHECK: 'true' },
+        euid: 501,
+      });
+
+      expect(checker.check('msg')).toBe('opted-out');
+      expect(notifier).not.toHaveBeenCalled();
+    });
+
+    it('root 実行時は update-notifier を呼ばない', () => {
+      const { checker, notifier } = createChecker({ euid: 0 });
+
+      expect(checker.check('msg')).toBe('running-as-root');
+      expect(notifier).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hostswitch.ts
+++ b/src/hostswitch.ts
@@ -2,7 +2,6 @@
 
 import chalk from 'chalk';
 import { Command } from 'commander';
-import updateNotifier from 'update-notifier';
 import packageJson from '../package.json';
 import { CliController } from './cli/CliController';
 import { HostSwitchFacade } from './cli/HostSwitchFacade';
@@ -10,6 +9,7 @@ import { CliUserInterface } from './cli/ui/CliUserInterface';
 import { InteractiveUserInterface } from './cli/ui/InteractiveUserInterface';
 import { createConfig } from './config';
 import { HostSwitchService } from './core/HostSwitchService';
+import { UpdateChecker } from './core/UpdateChecker';
 import { ChalkLogger } from './infrastructure/ChalkLogger';
 import { DnsCacheFlusher } from './infrastructure/DnsCacheFlusher';
 import { FileSystemAdapter } from './infrastructure/FileSystemAdapter';
@@ -141,11 +141,7 @@ async function main() {
     'Update with the tool you used to install hostswitch, e.g.\n' +
     chalk.cyan('{updateCommand}');
 
-  updateNotifier({
-    pkg: packageJson,
-    updateCheckInterval: 0,
-    shouldNotifyInNpmScript: true,
-  }).notify({ isGlobal: true, message: updateMessage });
+  new UpdateChecker(packageJson).check(updateMessage);
 
   const program = parseCommands();
 


### PR DESCRIPTION
## Summary

更新チェックの3つの問題をまとめて直します。実装は `src/core/UpdateChecker.ts` に切り出しました。

## Related Issue

Closes #75 / Refs #84

## 直したもの

**1. 毎回起動時にチェックが走っていた**

`updateCheckInterval: 0` は「キャッシュを使わず毎回チェックを開始する」指定です。CLAUDE.md には以前から「24時間キャッシュ」と書かれていましたが、実装が伴っていませんでした。update-notifier の既定と同じ24時間にしています。

**2. 無効化する手段が無かった**

`HOSTSWITCH_NO_UPDATE_CHECK=true` で完全にスキップします。これも CLAUDE.md に書かれていながら未実装でした。

**3. root 実行時に root 所有の設定ファイルを作りうる ← これが一番厄介**

`switch` は sudo で自分を再実行します。その run で update-notifier が結果を config store に書くと、**そのファイルが root 所有になり、以降の非 sudo 実行がすべて `EACCES` で落ちる**ようになります。root（euid 0）で動いている間はチェックごとスキップするようにしました。

## 設計

**`src/core/UpdateChecker.ts` は CLAUDE.md が以前から参照していたパス**です。実体が無いまま参照だけが残っていたので、今回の切り出しでその不一致も解消されます（#84 の一項目）。

スキップ判定を `skipReason(): 'opted-out' | 'running-as-root' | null` として公開しているので、**ネットワークにも実際の config store にも触れずに単体テストできます**。`env` / `getEuid` / `notifier` を注入可能にしてあります。

## テスト

`UpdateChecker` 9ケース:

- 通常ユーザではチェックする / `HOSTSWITCH_NO_UPDATE_CHECK=true` で見送る / **`true` 以外の値では見送らない**
- root（euid 0）で見送る / **euid を取れない環境（Windows）ではチェックする**
- チェック時に24時間間隔を渡している / **interval 0 にはしない**
- オプトアウト時・root 時は update-notifier をそもそも呼ばない

テストは **271 → 280件**。`npm run check` 通過。

## 手元での確認

```
通常ユーザ     -> skipReason = null
オプトアウト   -> skipReason = "opted-out"
root実行       -> skipReason = "running-as-root"
```

`HOSTSWITCH_NO_UPDATE_CHECK=true hostswitch list` が正常に動くことも確認済みです。

## 補足: #84 について

このPRで `UpdateChecker.ts` の参照と更新チェック関連の記述は実態と一致します。**#84 は open のままにします** — `ARCHITECTURE_DIAGRAMS.md` が存在しない件が残っているためです。

## Checklist

- [x] `npm run check` passes locally
- [x] Tests added
- [x] Documentation updated (CLAUDE.md / README.md / README.ja.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
