### PR TITLE
feat: list and restore hosts backups, with retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ All commands are defined using Commander.js:
 - `delete <name>` / `rm <name>`: Remove profile
 - `show <name>` / `cat <name>`: Display profile contents
 - `edit <name>`: Open profile in editor (uses $EDITOR or vi)
+- `backups` / `backup-list`: List available hosts backups (newest first)
+- `restore [id]`: Restore the hosts file from a backup, most recent if `id` is omitted (requires sudo)
 
 ### Interactive Mode
 Running `hostswitch` without any arguments launches an interactive mode:
@@ -206,7 +208,7 @@ Running `hostswitch` without any arguments launches an interactive mode:
    - Windows: `C:\Windows\System32\drivers\etc\hosts`
 2. **Editor Selection**: Uses `$EDITOR` environment variable, falls back to `vi`
 3. **Profile Validation**: Cannot delete currently active profile
-4. **Backup Strategy**: Only backs up if hosts file was modified or no current profile exists
+4. **Backup Strategy**: Only backs up if hosts file was modified or no current profile exists. The most recent 20 backups are kept; older ones are pruned on each switch/restore. Restore replays a backup through the same atomic write path as switch and clears the current profile afterwards
 5. **TypeScript Configuration**: 
    - Target: ES2022
    - Module: CommonJS

--- a/README.ja.md
+++ b/README.ja.md
@@ -341,6 +341,18 @@ MIT License - 詳細は[LICENSE](LICENSE)ファイルを参照してください
 
 [milkmaccya2](https://github.com/milkmaccya2)
 
+## バックアップ
+
+切り替えのたびに現在の hosts ファイルが `~/.hostswitch/backups/` に退避されます。一覧・復元:
+
+```bash
+hostswitch backups          # バックアップ一覧（新しい順）
+hostswitch restore          # 最新のバックアップを復元（要sudo）
+hostswitch restore <id>     # 指定したバックアップを復元
+```
+
+直近20件を保持し、古いものは自動削除されます。復元すると、復元後の hosts が特定のプロファイルと一致するとは限らないため、アクティブなプロファイルは解除されます。
+
 ## 貢献
 
 バグ報告や機能追加のリクエストは[GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues)で受け付けています。

--- a/README.md
+++ b/README.md
@@ -319,6 +319,18 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 [milkmaccya2](https://github.com/milkmaccya2)
 
+## Backups
+
+Every switch backs up your current hosts file under `~/.hostswitch/backups/`. List and restore them:
+
+```bash
+hostswitch backups          # list available backups, newest first
+hostswitch restore          # restore the most recent backup (requires sudo)
+hostswitch restore <id>     # restore a specific backup
+```
+
+The most recent 20 backups are kept; older ones are pruned automatically. Restoring clears the active profile, since a restored hosts file may not match any profile.
+
 ## Contributing
 
 Bug reports and feature requests are welcome at [GitHub Issues](https://github.com/milkmaccya2/hostswitch/issues).

--- a/src/cli/CliController.ts
+++ b/src/cli/CliController.ts
@@ -2,18 +2,29 @@ import type { ICommand, IUserInterface } from '../interfaces';
 import { CreateProfileCommand } from './commands/CreateProfileCommand';
 import { DeleteProfileCommand } from './commands/DeleteProfileCommand';
 import { EditProfileCommand } from './commands/EditProfileCommand';
+import { ListBackupsCommand } from './commands/ListBackupsCommand';
 import { ListProfilesCommand } from './commands/ListProfilesCommand';
+import { RestoreBackupCommand } from './commands/RestoreBackupCommand';
 import { ShowProfileCommand } from './commands/ShowProfileCommand';
 import { SwitchProfileCommand } from './commands/SwitchProfileCommand';
 import type { HostSwitchFacade } from './HostSwitchFacade';
 
-export type CommandType = 'list' | 'create' | 'switch' | 'edit' | 'show' | 'delete';
+export type CommandType =
+  | 'list'
+  | 'create'
+  | 'switch'
+  | 'edit'
+  | 'show'
+  | 'delete'
+  | 'backup-list'
+  | 'restore';
 
 export interface CommandParams {
   name?: string;
   fromCurrent?: boolean;
   force?: boolean;
   flushDns?: boolean;
+  backupId?: string;
 }
 
 export class CliController {
@@ -39,6 +50,12 @@ export class CliController {
     switch (type) {
       case 'list':
         return new ListProfilesCommand(this.facade);
+
+      case 'backup-list':
+        return new ListBackupsCommand(this.facade);
+
+      case 'restore':
+        return new RestoreBackupCommand(this.facade, params.backupId);
 
       case 'create':
         if (!params.name) {

--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -57,6 +57,63 @@ export class HostSwitchFacade {
     }
   }
 
+  async listBackups(): Promise<ICommandResult> {
+    try {
+      const backups = this.hostSwitchService.getBackups();
+      return {
+        success: true,
+        data: { backups },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to list backups: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  async restoreBackup(id?: string): Promise<ICommandResult> {
+    try {
+      const backups = this.hostSwitchService.getBackups();
+      if (backups.length === 0) {
+        return { success: false, message: 'No backups found' };
+      }
+      if (id && !backups.some((backup) => backup.id === id)) {
+        return { success: false, message: `Backup "${id}" not found` };
+      }
+
+      const args = id ? ['restore', id] : ['restore'];
+
+      // switch と同じく、書き込みには sudo が要る
+      if (this.permissionChecker.requiresSudo(this.hostSwitchService.getHostsPath())) {
+        return this.needsSudoResult(args);
+      }
+
+      const result = this.hostSwitchService.restoreBackup(id);
+      if (result.success) {
+        let message = result.message ?? 'Restored from backup';
+        if (result.backupPath) {
+          message += ' (previous hosts backed up)';
+        }
+        return { success: true, message };
+      }
+      // 事前の requiresSudo チェックは通ったが、実際の書き込みで権限が
+      // 足りなかった場合。ここでも昇格に必要な情報を渡す
+      if (result.requiresSudo) {
+        return this.needsSudoResult(args);
+      }
+      return {
+        success: false,
+        message: result.message || 'Failed to restore backup',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to restore backup: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
   async switchProfile(name: string, options: SwitchOptions = {}): Promise<ICommandResult> {
     const validation = this.validateProfileName(name);
     if (!validation.success) {
@@ -72,13 +129,7 @@ export class HostSwitchFacade {
       }
 
       if (this.permissionChecker.requiresSudo(this.hostSwitchService.getHostsPath())) {
-        return {
-          success: false,
-          requiresSudo: true,
-          sudoCommand: `sudo hostswitch switch ${name}`,
-          sudoArgs: ['switch', name],
-          message: 'This operation requires sudo privileges',
-        };
+        return this.needsSudoResult(['switch', name]);
       }
 
       const result = await this.hostSwitchService.switchProfile(name, options);
@@ -95,12 +146,15 @@ export class HostSwitchFacade {
           message,
           data: { switchResult: result },
         };
-      } else {
-        return {
-          success: false,
-          message: result.message || 'Failed to switch profile',
-        };
       }
+      // 事前チェックは通ったが実際の書き込みで権限が足りなかった場合
+      if (result.requiresSudo) {
+        return this.needsSudoResult(['switch', name]);
+      }
+      return {
+        success: false,
+        message: result.message || 'Failed to switch profile',
+      };
     } catch (error) {
       return {
         success: false,
@@ -251,6 +305,17 @@ export class HostSwitchFacade {
       return 'Profile name cannot be empty';
     }
     return this.hostSwitchService.isValidProfileName(input) ? true : INVALID_PROFILE_NAME_MESSAGE;
+  }
+
+  /** 昇格が必要なときに UI へ返す結果。sudoArgs は elevate にそのまま渡る */
+  private needsSudoResult(args: string[]): ICommandResult {
+    return {
+      success: false,
+      requiresSudo: true,
+      sudoCommand: `sudo hostswitch ${args.join(' ')}`,
+      sudoArgs: args,
+      message: 'This operation requires sudo privileges',
+    };
   }
 
   private validateProfileName(name: string): ICommandResult {

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -28,6 +28,8 @@ describe('HostSwitchFacade', () => {
     getHostsPath: ReturnType<typeof vi.fn>;
     isProfileApplied: ReturnType<typeof vi.fn>;
     isValidProfileName: ReturnType<typeof vi.fn>;
+    getBackups: ReturnType<typeof vi.fn>;
+    restoreBackup: ReturnType<typeof vi.fn>;
   };
   let _mockLogger: ILogger;
   let mockProcessManager: IProcessManager;
@@ -47,6 +49,8 @@ describe('HostSwitchFacade', () => {
       getHostsPath: vi.fn().mockReturnValue('/etc/hosts'),
       isProfileApplied: vi.fn().mockReturnValue(true),
       isValidProfileName: vi.fn((name: string) => /^[a-zA-Z0-9_-]+$/.test(name)),
+      getBackups: vi.fn().mockReturnValue([]),
+      restoreBackup: vi.fn(),
     };
 
     _mockLogger = {
@@ -377,6 +381,85 @@ describe('HostSwitchFacade', () => {
 
       expect(result).toHaveLength(2);
       expect(result.map((p) => p.name)).toEqual(['staging', 'production']);
+    });
+  });
+
+  describe('listBackups', () => {
+    it('サービスの一覧を data に載せて返す', async () => {
+      const backups = [{ id: 'a', path: '/b/a', createdAt: null }];
+      mockService.getBackups.mockReturnValue(backups);
+
+      const result = await facade.listBackups();
+
+      expect(result.success).toBe(true);
+      expect((result.data as { backups: unknown }).backups).toEqual(backups);
+    });
+  });
+
+  describe('restoreBackup', () => {
+    it('バックアップが無ければ失敗を返す', async () => {
+      mockService.getBackups.mockReturnValue([]);
+
+      const result = await facade.restoreBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('No backups');
+    });
+
+    it('存在しない id を弾く', async () => {
+      mockService.getBackups.mockReturnValue([{ id: 'a', path: '/b/a', createdAt: null }]);
+
+      const result = await facade.restoreBackup('zzz');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+
+    it('sudo が必要なら sudoArgs を返す（id あり）', async () => {
+      mockService.getBackups.mockReturnValue([{ id: 'a', path: '/b/a', createdAt: null }]);
+      vi.mocked(mockPermissionChecker.requiresSudo).mockReturnValue(true);
+
+      const result = await facade.restoreBackup('a');
+
+      expect(result.requiresSudo).toBe(true);
+      expect(result.sudoArgs).toEqual(['restore', 'a']);
+    });
+
+    it('sudo が必要なら sudoArgs を返す（id 省略）', async () => {
+      mockService.getBackups.mockReturnValue([{ id: 'a', path: '/b/a', createdAt: null }]);
+      vi.mocked(mockPermissionChecker.requiresSudo).mockReturnValue(true);
+
+      const result = await facade.restoreBackup();
+
+      expect(result.sudoArgs).toEqual(['restore']);
+    });
+
+    it('sudo 不要ならサービスに委譲する', async () => {
+      mockService.getBackups.mockReturnValue([{ id: 'a', path: '/b/a', createdAt: null }]);
+      vi.mocked(mockPermissionChecker.requiresSudo).mockReturnValue(false);
+      mockService.restoreBackup.mockReturnValue({
+        success: true,
+        message: "Restored hosts from backup 'a'.",
+        backupPath: '/b/prev',
+      });
+
+      const result = await facade.restoreBackup('a');
+
+      expect(mockService.restoreBackup).toHaveBeenCalledWith('a');
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('previous hosts backed up');
+    });
+
+    it('事前チェックを通ってもサービスが requiresSudo を返したら sudoArgs を付ける', async () => {
+      // accessSync が書けると誤判定し、実際の rename が EACCES になるケース
+      mockService.getBackups.mockReturnValue([{ id: 'a', path: '/b/a', createdAt: null }]);
+      vi.mocked(mockPermissionChecker.requiresSudo).mockReturnValue(false);
+      mockService.restoreBackup.mockReturnValue({ success: false, requiresSudo: true });
+
+      const result = await facade.restoreBackup('a');
+
+      expect(result.requiresSudo).toBe(true);
+      expect(result.sudoArgs).toEqual(['restore', 'a']);
     });
   });
 });

--- a/src/cli/commands/ListBackupsCommand.ts
+++ b/src/cli/commands/ListBackupsCommand.ts
@@ -1,0 +1,10 @@
+import type { ICommand, ICommandResult } from '../../interfaces';
+import type { HostSwitchFacade } from '../HostSwitchFacade';
+
+export class ListBackupsCommand implements ICommand {
+  constructor(private facade: HostSwitchFacade) {}
+
+  async execute(): Promise<ICommandResult> {
+    return this.facade.listBackups();
+  }
+}

--- a/src/cli/commands/RestoreBackupCommand.ts
+++ b/src/cli/commands/RestoreBackupCommand.ts
@@ -1,0 +1,13 @@
+import type { ICommand, ICommandResult } from '../../interfaces';
+import type { HostSwitchFacade } from '../HostSwitchFacade';
+
+export class RestoreBackupCommand implements ICommand {
+  constructor(
+    private facade: HostSwitchFacade,
+    private backupId?: string
+  ) {}
+
+  async execute(): Promise<ICommandResult> {
+    return this.facade.restoreBackup(this.backupId);
+  }
+}

--- a/src/cli/commands/__tests__/Commands.test.ts
+++ b/src/cli/commands/__tests__/Commands.test.ts
@@ -4,7 +4,9 @@ import type { HostSwitchFacade } from '../../HostSwitchFacade';
 import { CreateProfileCommand } from '../CreateProfileCommand';
 import { DeleteProfileCommand } from '../DeleteProfileCommand';
 import { EditProfileCommand } from '../EditProfileCommand';
+import { ListBackupsCommand } from '../ListBackupsCommand';
 import { ListProfilesCommand } from '../ListProfilesCommand';
+import { RestoreBackupCommand } from '../RestoreBackupCommand';
 import { ShowProfileCommand } from '../ShowProfileCommand';
 import { SwitchProfileCommand } from '../SwitchProfileCommand';
 
@@ -20,6 +22,8 @@ describe('Command Classes', () => {
       showProfile: vi.fn(),
       deleteProfile: vi.fn(),
       elevate: vi.fn(),
+      listBackups: vi.fn(),
+      restoreBackup: vi.fn(),
       getCurrentProfile: vi.fn(),
       getDeletableProfiles: vi.fn(),
     };
@@ -115,6 +119,41 @@ describe('Command Classes', () => {
 
       expect(result).toBe(expectedResult);
       expect(mockFacade.deleteProfile).toHaveBeenCalledWith('old-profile', false);
+    });
+  });
+
+  describe('ListBackupsCommand', () => {
+    it('facade.listBackups を呼ぶ', async () => {
+      const expected: ICommandResult = { success: true, data: { backups: [] } };
+      vi.mocked(mockFacade.listBackups!).mockResolvedValue(expected);
+
+      const command = new ListBackupsCommand(mockFacade as HostSwitchFacade);
+      const result = await command.execute();
+
+      expect(mockFacade.listBackups).toHaveBeenCalled();
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('RestoreBackupCommand', () => {
+    it('id を facade.restoreBackup に渡す', async () => {
+      const expected: ICommandResult = { success: true, message: 'Restored' };
+      vi.mocked(mockFacade.restoreBackup!).mockResolvedValue(expected);
+
+      const command = new RestoreBackupCommand(mockFacade as HostSwitchFacade, 'abc');
+      const result = await command.execute();
+
+      expect(mockFacade.restoreBackup).toHaveBeenCalledWith('abc');
+      expect(result).toBe(expected);
+    });
+
+    it('id 省略時は undefined を渡す', async () => {
+      vi.mocked(mockFacade.restoreBackup!).mockResolvedValue({ success: true });
+
+      const command = new RestoreBackupCommand(mockFacade as HostSwitchFacade);
+      await command.execute();
+
+      expect(mockFacade.restoreBackup).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -1,4 +1,5 @@
 import type {
+  BackupInfo,
   Choice,
   Elevate,
   ICommandResult,
@@ -136,6 +137,18 @@ export class CliUserInterface implements IUserInterface {
         profilesData.profiles.forEach((profile) => {
           const status = profile.isCurrent ? ' (current)' : '';
           this.logger.info(`  ${profile.name}${status}`);
+        });
+      }
+    } else if (data && typeof data === 'object' && 'backups' in data) {
+      // Backup list command
+      const backupsData = data as { backups: BackupInfo[] };
+      if (backupsData.backups.length === 0) {
+        this.showMessage('No backups found', 'info');
+      } else {
+        this.showMessage('Available backups (newest first):', 'info');
+        backupsData.backups.forEach((backup) => {
+          const when = backup.createdAt ? backup.createdAt.toLocaleString() : 'unknown time';
+          this.logger.info(`  ${backup.id}  (${when})`);
         });
       }
     } else if (data && typeof data === 'object' && 'content' in data) {

--- a/src/core/BackupManager.ts
+++ b/src/core/BackupManager.ts
@@ -1,5 +1,10 @@
 import * as path from 'node:path';
-import type { BackupResult, HostSwitchConfig, IFileSystem } from '../interfaces';
+import type { BackupInfo, BackupResult, HostSwitchConfig, IFileSystem } from '../interfaces';
+
+const BACKUP_PREFIX = 'hosts_';
+
+/** 直近この件数を残し、それより古いバックアップは switch のたびに削除する */
+export const DEFAULT_BACKUP_RETENTION = 20;
 
 export class BackupManager {
   constructor(
@@ -20,7 +25,7 @@ export class BackupManager {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const backupPath = path.join(this.config.backupDir, `hosts_${timestamp}`);
+    const backupPath = path.join(this.config.backupDir, `${BACKUP_PREFIX}${timestamp}`);
 
     try {
       this.fileSystem.copySync(this.config.hostsPath, backupPath);
@@ -29,4 +34,66 @@ export class BackupManager {
       return { success: false, message: (err as Error).message };
     }
   }
+
+  /**
+   * バックアップを新しい順に返す。ファイル名のタイムスタンプは辞書順が
+   * そのまま時系列順になるので、名前でソートするだけでよい。
+   */
+  listBackups(): BackupInfo[] {
+    let files: string[];
+    try {
+      files = this.fileSystem.readdirSync(this.config.backupDir);
+    } catch {
+      return [];
+    }
+
+    return files
+      .filter((file) => file.startsWith(BACKUP_PREFIX))
+      .sort()
+      .reverse()
+      .map((file) => {
+        const id = file.slice(BACKUP_PREFIX.length);
+        return {
+          id,
+          path: path.join(this.config.backupDir, file),
+          createdAt: parseBackupTimestamp(id),
+        };
+      });
+  }
+
+  getBackup(id: string): BackupInfo | undefined {
+    return this.listBackups().find((backup) => backup.id === id);
+  }
+
+  /**
+   * 直近 keep 件を残して古いものを削除する。ベストエフォートで、
+   * 個々の削除に失敗しても止めない（バックアップ本体の処理を妨げない）。
+   */
+  pruneBackups(keep: number = DEFAULT_BACKUP_RETENTION): void {
+    if (keep < 0) {
+      return;
+    }
+    const stale = this.listBackups().slice(keep);
+    for (const backup of stale) {
+      try {
+        this.fileSystem.unlinkSync(backup.path);
+      } catch {
+        // 消せなくても致命的ではない
+      }
+    }
+  }
+}
+
+/**
+ * `2026-08-05T14-32-10-123Z` を Date に戻す。時刻区切りの `-` を元の
+ * `:` と `.` に戻してから解釈する。想定外の形式なら null。
+ */
+function parseBackupTimestamp(id: string): Date | null {
+  const match = id.match(/^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/);
+  if (!match) {
+    return null;
+  }
+  const [, date, h, m, s, ms] = match;
+  const parsed = new Date(`${date}T${h}:${m}:${s}.${ms}Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/src/core/CurrentProfileManager.ts
+++ b/src/core/CurrentProfileManager.ts
@@ -21,6 +21,17 @@ export class CurrentProfileManager {
     });
   }
 
+  /**
+   * 現在のプロファイル記録を消す。バックアップから復元した hosts は
+   * 特定のプロファイルと一致するとは限らないので、復元後はどのプロファイルも
+   * アクティブでない状態にする。
+   */
+  clearCurrentProfile(): void {
+    if (this.fileSystem.existsSync(this.config.currentProfileFile)) {
+      this.fileSystem.unlinkSync(this.config.currentProfileFile);
+    }
+  }
+
   isHostsModified(): boolean {
     const currentData = this.getCurrentProfileData();
     if (!currentData || !currentData.checksum) {

--- a/src/core/HostSwitchService.ts
+++ b/src/core/HostSwitchService.ts
@@ -1,4 +1,5 @@
 import type {
+  BackupInfo,
   CreateProfileResult,
   DnsFlushResult,
   HostSwitchConfig,
@@ -6,6 +7,7 @@ import type {
   IFileSystem,
   ILogger,
   ProfileInfo,
+  RestoreResult,
   SwitchOptions,
   SwitchResult,
 } from '../interfaces';
@@ -53,6 +55,60 @@ export class HostSwitchService {
     return this.profileManager.getProfiles(currentProfile);
   }
 
+  getBackups(): BackupInfo[] {
+    return this.backupManager.listBackups();
+  }
+
+  /**
+   * バックアップから hosts を復元する。id を省略すると最新を使う。
+   * switch と同じく、書き込みはアトミック置換で行い、書けない場合は
+   * requiresSudo を返して呼び出し側に昇格させる。
+   *
+   * 復元した hosts は特定のプロファイルと一致するとは限らないので、
+   * 復元後は current プロファイルを解除する。
+   */
+  restoreBackup(id?: string): RestoreResult {
+    const backups = this.backupManager.listBackups();
+    if (backups.length === 0) {
+      return { success: false, message: 'No backups found.' };
+    }
+
+    const target = id ? backups.find((backup) => backup.id === id) : backups[0];
+    if (!target) {
+      return { success: false, message: `Backup '${id}' not found.` };
+    }
+
+    // 復元前の hosts も退避しておく。取れないなら進めない
+    let backupPath: string | undefined;
+    if (this.currentProfileManager.isHostsModified() || !this.getCurrentProfile()) {
+      const backup = this.backupManager.backupHosts();
+      if (!backup.success) {
+        return {
+          success: false,
+          message: `Aborted: could not back up the current hosts file (${backup.message}).`,
+        };
+      }
+      backupPath = backup.path;
+    }
+
+    try {
+      this.replaceHostsFile(target.path);
+      this.currentProfileManager.clearCurrentProfile();
+      this.backupManager.pruneBackups();
+      return {
+        success: true,
+        message: `Restored hosts from backup '${target.id}'.`,
+        backupPath,
+      };
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code === 'EACCES') {
+        return { success: false, message: 'Permission denied. Run with sudo.', requiresSudo: true };
+      }
+      return { success: false, message: `Error restoring backup: ${error.message}` };
+    }
+  }
+
   createProfile(name: string, fromCurrent: boolean = false): CreateProfileResult {
     return this.profileManager.createProfile(name, fromCurrent);
   }
@@ -94,6 +150,7 @@ export class HostSwitchService {
       const profilePath = this.profileManager.getProfilePath(name);
       this.replaceHostsFile(profilePath);
       this.currentProfileManager.setCurrentProfile(name);
+      this.backupManager.pruneBackups();
 
       // hostsの書き換えが済んだ後に行う。フラッシュが失敗しても切り替えは成功
       const dnsFlush = await this.flushDnsCache(options);

--- a/src/core/__tests__/BackupManager.test.ts
+++ b/src/core/__tests__/BackupManager.test.ts
@@ -89,4 +89,99 @@ describe('BackupManager', () => {
       expect(mocks.mockFileSystem.existsSync(result.path!)).toBe(true);
     });
   });
+
+  describe('listBackups()', () => {
+    it('hosts_ で始まるファイルを新しい順に返す', () => {
+      mocks.mockFileSystem.setFile(
+        `${mocks.config.backupDir}/hosts_2026-08-05T14-32-10-123Z`,
+        'old'
+      );
+      mocks.mockFileSystem.setFile(
+        `${mocks.config.backupDir}/hosts_2026-08-07T09-15-00-000Z`,
+        'new'
+      );
+      // バックアップではないファイルは無視する
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/notes.txt`, 'x');
+
+      const backups = backupManager.listBackups();
+
+      expect(backups).toHaveLength(2);
+      expect(backups[0].id).toBe('2026-08-07T09-15-00-000Z');
+      expect(backups[1].id).toBe('2026-08-05T14-32-10-123Z');
+    });
+
+    it('ファイル名から作成日時を復元する', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_2026-08-05T14-32-10-123Z`, 'x');
+
+      const [backup] = backupManager.listBackups();
+
+      expect(backup.createdAt).toEqual(new Date('2026-08-05T14:32:10.123Z'));
+    });
+
+    it('想定外の名前は createdAt を null にする', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_manual-copy`, 'x');
+
+      const [backup] = backupManager.listBackups();
+
+      expect(backup.id).toBe('manual-copy');
+      expect(backup.createdAt).toBeNull();
+    });
+
+    it('バックアップディレクトリが読めなくても空配列を返す', () => {
+      const original = mocks.mockFileSystem.readdirSync;
+      mocks.mockFileSystem.readdirSync = () => {
+        throw new Error('ENOENT');
+      };
+
+      expect(backupManager.listBackups()).toEqual([]);
+
+      mocks.mockFileSystem.readdirSync = original;
+    });
+  });
+
+  describe('getBackup()', () => {
+    it('id で1件取得する', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_2026-08-05T14-32-10-123Z`, 'x');
+
+      expect(backupManager.getBackup('2026-08-05T14-32-10-123Z')).toBeDefined();
+      expect(backupManager.getBackup('nope')).toBeUndefined();
+    });
+  });
+
+  describe('pruneBackups()', () => {
+    it('直近 keep 件を残して古いものを消す', () => {
+      for (const ts of [
+        '2026-08-01T00-00-00-000Z',
+        '2026-08-02T00-00-00-000Z',
+        '2026-08-03T00-00-00-000Z',
+        '2026-08-04T00-00-00-000Z',
+      ]) {
+        mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_${ts}`, 'x');
+      }
+
+      backupManager.pruneBackups(2);
+
+      const remaining = backupManager.listBackups().map((b) => b.id);
+      expect(remaining).toEqual(['2026-08-04T00-00-00-000Z', '2026-08-03T00-00-00-000Z']);
+    });
+
+    it('件数が保持数以下なら何も消さない', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_2026-08-01T00-00-00-000Z`, 'x');
+
+      backupManager.pruneBackups(20);
+
+      expect(backupManager.listBackups()).toHaveLength(1);
+    });
+
+    it('削除に失敗しても止まらない', () => {
+      for (const ts of ['2026-08-01T00-00-00-000Z', '2026-08-02T00-00-00-000Z']) {
+        mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_${ts}`, 'x');
+      }
+      mocks.mockFileSystem.unlinkSync = () => {
+        throw new Error('locked');
+      };
+
+      expect(() => backupManager.pruneBackups(1)).not.toThrow();
+    });
+  });
 });

--- a/src/core/__tests__/HostSwitchService.test.ts
+++ b/src/core/__tests__/HostSwitchService.test.ts
@@ -327,4 +327,105 @@ describe('HostSwitchService - 統合テスト', () => {
       expect(mocks.mockPermissionChecker.calls).toHaveLength(0);
     });
   });
+
+  describe('バックアップの復元', () => {
+    const seedBackups = () => {
+      mocks.mockFileSystem.setFile(
+        `${mocks.config.backupDir}/hosts_2026-08-05T14-32-10-123Z`,
+        '127.0.0.1 old'
+      );
+      mocks.mockFileSystem.setFile(
+        `${mocks.config.backupDir}/hosts_2026-08-07T09-15-00-000Z`,
+        '127.0.0.1 newer'
+      );
+    };
+
+    it('id 省略時は最新のバックアップを hosts に復元する', () => {
+      seedBackups();
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, '127.0.0.1 current');
+
+      const result = service.restoreBackup();
+
+      expect(result.success).toBe(true);
+      expect(mocks.mockFileSystem.getFile(mocks.config.hostsPath)).toBe('127.0.0.1 newer');
+    });
+
+    it('id 指定でそのバックアップを復元する', () => {
+      seedBackups();
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, '127.0.0.1 current');
+
+      const result = service.restoreBackup('2026-08-05T14-32-10-123Z');
+
+      expect(result.success).toBe(true);
+      expect(mocks.mockFileSystem.getFile(mocks.config.hostsPath)).toBe('127.0.0.1 old');
+    });
+
+    it('復元後は current プロファイルを解除する', () => {
+      seedBackups();
+      service.createProfile('dev');
+      // createProfile 直後に current を設定しておく
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, '127.0.0.1 current');
+      mocks.mockFileSystem.writeJsonSync(mocks.config.currentProfileFile, {
+        profile: 'dev',
+        checksum: 'x',
+        updatedAt: 'now',
+      });
+
+      service.restoreBackup();
+
+      expect(service.getCurrentProfile()).toBeNull();
+    });
+
+    it('復元前の hosts も退避する', () => {
+      seedBackups();
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, '127.0.0.1 current');
+
+      const result = service.restoreBackup();
+
+      expect(result.backupPath).toBeDefined();
+      expect(mocks.mockFileSystem.getFile(result.backupPath as string)).toBe('127.0.0.1 current');
+    });
+
+    it('バックアップが無ければ失敗を返す', () => {
+      const result = service.restoreBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('No backups');
+    });
+
+    it('存在しない id は失敗を返す', () => {
+      seedBackups();
+
+      const result = service.restoreBackup('nope');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+
+    it('EACCES なら requiresSudo を返す', () => {
+      seedBackups();
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, '127.0.0.1 current');
+      mocks.mockFileSystem.renameSync = () => {
+        const error = new Error('Permission denied') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        throw error;
+      };
+
+      const result = service.restoreBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.requiresSudo).toBe(true);
+    });
+  });
+
+  describe('getBackups()', () => {
+    it('BackupManager の一覧をそのまま返す', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_2026-08-05T14-32-10-123Z`, 'x');
+
+      const backups = service.getBackups();
+
+      expect(backups).toHaveLength(1);
+      expect(backups[0].id).toBe('2026-08-05T14-32-10-123Z');
+    });
+  });
 });

--- a/src/hostswitch.ts
+++ b/src/hostswitch.ts
@@ -125,6 +125,28 @@ function parseCommands() {
       });
     });
 
+  // Backup list command
+  program
+    .command('backups')
+    .alias('backup-list')
+    .description('List available hosts backups')
+    .action(async () => {
+      const ui = new CliUserInterface(logger, elevate);
+      const controller = new CliController(facade, ui);
+      await controller.executeCommand('backup-list');
+    });
+
+  // Restore command
+  program
+    .command('restore')
+    .argument('[id]', 'Backup id to restore (defaults to the most recent)')
+    .description('Restore the hosts file from a backup (requires sudo)')
+    .action(async (id: string | undefined) => {
+      const ui = new CliUserInterface(logger, elevate);
+      const controller = new CliController(facade, ui);
+      await controller.executeCommand('restore', { backupId: id });
+    });
+
   return program;
 }
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -99,6 +99,23 @@ export interface BackupResult {
   message?: string;
 }
 
+export interface BackupInfo {
+  /** restore で指定する識別子。ファイル名のタイムスタンプ部分 */
+  id: string;
+  /** バックアップファイルの絶対パス */
+  path: string;
+  /** バックアップが作られた日時。ファイル名から復元できない場合は null */
+  createdAt: Date | null;
+}
+
+export interface RestoreResult {
+  success: boolean;
+  message?: string;
+  /** 復元前の hosts を退避した先 */
+  backupPath?: string;
+  requiresSudo?: boolean;
+}
+
 export interface CreateProfileResult {
   success: boolean;
   message?: string;


### PR DESCRIPTION
## Summary

バックアップは切り替えのたびに `~/.hostswitch/backups/` に作られていましたが、**ツールから見る手段も戻す手段も無く**、復元には手で `cp` するしかありませんでした。読み出し側を追加し、無限に溜まる問題も解消します。

## Related Issue

Closes #76

## 追加したコマンド

```bash
hostswitch backups          # バックアップ一覧（新しい順、日時つき）
hostswitch restore          # 最新のバックアップを復元（要sudo）
hostswitch restore <id>     # 指定したバックアップを復元
```

一覧の出力例:

```
Available backups (newest first):
  2026-08-07T09-15-00-000Z  (8/7/2026, 6:15:00 PM)
  2026-08-05T14-32-10-123Z  (8/5/2026, 11:32:10 PM)
```

`id` はファイル名のタイムスタンプ部分です。表示用の日時はファイル名からパースして復元しています（`statSync` に依存しません）。

## 設計

**復元は switch と同じ経路を通します。**

- sudo フロー（`requiresSudo` → `sudoArgs` → 昇格）
- アトミック置換（一時ファイル → `rename`）
- **復元前の hosts も退避**してから書き換え（退避に失敗したら中断）
- **復元後は current プロファイルを解除**。復元した hosts が特定のプロファイルと一致するとは限らないため（#76 に書かれていた「解除するのが自然」に従いました）

**保持ポリシー**: switch と restore のたびに直近20件を残して古いものを削除します（`DEFAULT_BACKUP_RETENTION`）。削除はベストエフォートで、個々の失敗では止まりません。

## 実装中に見つけて直したバグ

`needsSudoResult` に共通化する過程で、**switch にも潜在していた穴**を塞ぎました。

Facade の事前 `requiresSudo`（= `fs.accessSync(W_OK)`）が「書ける」と判定したのに、実際の `rename` が `EACCES` になる環境では、Service が `requiresSudo: true` を返すものの **`sudoArgs` が付かず**、UI が `No sudo command provided` を表示していました。この不一致はサンドボックス環境で実際に踏みました。switch / restore とも、この経路でも `sudoArgs` を補完するようにしています。

手元で確認（sudo のパスワード要求で止まる = 昇格経路に正しく到達）:

```
$ hostswitch restore
This operation requires sudo privileges. Rerunning with sudo...
sudo: a password is required
```

## テスト

- `BackupManager` — 一覧のソート・タイムスタンプ復元・想定外の名前・保持ポリシー・削除失敗時（+8ケース）
- `HostSwitchService` — id 省略/指定の復元・current 解除・復元前の退避・バックアップ無し・EACCES で requiresSudo（+8ケース）
- `HostSwitchFacade` — 一覧・存在しない id・sudoArgs（id あり/なし）・委譲・**EACCES 経路での sudoArgs 補完**（+6ケース）
- コマンドクラス2つ

テストは **276 → 302件**。`npm run check` 通過。

## Checklist

- [x] `npm run check` passes locally
- [x] Tests added
- [x] Documentation updated (README.md / README.ja.md / CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
