### PR TITLE
feat: add a status command showing current profile and drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ All commands are defined using Commander.js:
 - `delete <name>` / `rm <name>`: Remove profile
 - `show <name>` / `cat <name>`: Display profile contents
 - `edit <name>`: Open profile in editor (uses $EDITOR or vi)
+- `status`: Show the current profile, whether hosts drifted from it, last switch time, and latest backup
 - `backups` / `backup-list`: List available hosts backups (newest first)
 - `restore [id]`: Restore the hosts file from a backup, most recent if `id` is omitted (requires sudo)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -341,6 +341,14 @@ MIT License - 詳細は[LICENSE](LICENSE)ファイルを参照してください
 
 [milkmaccya2](https://github.com/milkmaccya2)
 
+## 状態確認
+
+```bash
+hostswitch status
+```
+
+現在のプロファイル、`/etc/hosts` がそれと一致しているか（`in sync` か `modified outside hostswitch`）、最後に切り替えた日時、直近のバックアップを表示します。
+
 ## バックアップ
 
 切り替えのたびに現在の hosts ファイルが `~/.hostswitch/backups/` に退避されます。一覧・復元:

--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 [milkmaccya2](https://github.com/milkmaccya2)
 
+## Status
+
+```bash
+hostswitch status
+```
+
+Shows the active profile, whether `/etc/hosts` still matches it (`in sync` vs `modified outside hostswitch`), when you last switched, and the most recent backup.
+
 ## Backups
 
 Every switch backs up your current hosts file under `~/.hostswitch/backups/`. List and restore them:

--- a/src/cli/CliController.ts
+++ b/src/cli/CliController.ts
@@ -6,6 +6,7 @@ import { ListBackupsCommand } from './commands/ListBackupsCommand';
 import { ListProfilesCommand } from './commands/ListProfilesCommand';
 import { RestoreBackupCommand } from './commands/RestoreBackupCommand';
 import { ShowProfileCommand } from './commands/ShowProfileCommand';
+import { StatusCommand } from './commands/StatusCommand';
 import { SwitchProfileCommand } from './commands/SwitchProfileCommand';
 import type { HostSwitchFacade } from './HostSwitchFacade';
 
@@ -17,7 +18,8 @@ export type CommandType =
   | 'show'
   | 'delete'
   | 'backup-list'
-  | 'restore';
+  | 'restore'
+  | 'status';
 
 export interface CommandParams {
   name?: string;
@@ -50,6 +52,9 @@ export class CliController {
     switch (type) {
       case 'list':
         return new ListProfilesCommand(this.facade);
+
+      case 'status':
+        return new StatusCommand(this.facade);
 
       case 'backup-list':
         return new ListBackupsCommand(this.facade);

--- a/src/cli/HostSwitchFacade.ts
+++ b/src/cli/HostSwitchFacade.ts
@@ -57,6 +57,18 @@ export class HostSwitchFacade {
     }
   }
 
+  async getStatus(): Promise<ICommandResult> {
+    try {
+      const status = this.hostSwitchService.getStatus();
+      return { success: true, data: { status } };
+    } catch (error) {
+      return {
+        success: false,
+        message: `Failed to get status: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
   async listBackups(): Promise<ICommandResult> {
     try {
       const backups = this.hostSwitchService.getBackups();

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -30,6 +30,7 @@ describe('HostSwitchFacade', () => {
     isValidProfileName: ReturnType<typeof vi.fn>;
     getBackups: ReturnType<typeof vi.fn>;
     restoreBackup: ReturnType<typeof vi.fn>;
+    getStatus: ReturnType<typeof vi.fn>;
   };
   let _mockLogger: ILogger;
   let mockProcessManager: IProcessManager;
@@ -51,6 +52,7 @@ describe('HostSwitchFacade', () => {
       isValidProfileName: vi.fn((name: string) => /^[a-zA-Z0-9_-]+$/.test(name)),
       getBackups: vi.fn().mockReturnValue([]),
       restoreBackup: vi.fn(),
+      getStatus: vi.fn(),
     };
 
     _mockLogger = {
@@ -460,6 +462,24 @@ describe('HostSwitchFacade', () => {
 
       expect(result.requiresSudo).toBe(true);
       expect(result.sudoArgs).toEqual(['restore', 'a']);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('サービスの status を data に載せる', async () => {
+      const status = {
+        currentProfile: 'dev',
+        hostsPath: '/etc/hosts',
+        modified: false,
+        updatedAt: null,
+        latestBackup: null,
+      };
+      mockService.getStatus.mockReturnValue(status);
+
+      const result = await facade.getStatus();
+
+      expect(result.success).toBe(true);
+      expect((result.data as { status: unknown }).status).toEqual(status);
     });
   });
 });

--- a/src/cli/commands/StatusCommand.ts
+++ b/src/cli/commands/StatusCommand.ts
@@ -1,0 +1,10 @@
+import type { ICommand, ICommandResult } from '../../interfaces';
+import type { HostSwitchFacade } from '../HostSwitchFacade';
+
+export class StatusCommand implements ICommand {
+  constructor(private facade: HostSwitchFacade) {}
+
+  async execute(): Promise<ICommandResult> {
+    return this.facade.getStatus();
+  }
+}

--- a/src/cli/commands/__tests__/Commands.test.ts
+++ b/src/cli/commands/__tests__/Commands.test.ts
@@ -8,6 +8,7 @@ import { ListBackupsCommand } from '../ListBackupsCommand';
 import { ListProfilesCommand } from '../ListProfilesCommand';
 import { RestoreBackupCommand } from '../RestoreBackupCommand';
 import { ShowProfileCommand } from '../ShowProfileCommand';
+import { StatusCommand } from '../StatusCommand';
 import { SwitchProfileCommand } from '../SwitchProfileCommand';
 
 describe('Command Classes', () => {
@@ -24,6 +25,7 @@ describe('Command Classes', () => {
       elevate: vi.fn(),
       listBackups: vi.fn(),
       restoreBackup: vi.fn(),
+      getStatus: vi.fn(),
       getCurrentProfile: vi.fn(),
       getDeletableProfiles: vi.fn(),
     };
@@ -154,6 +156,19 @@ describe('Command Classes', () => {
       await command.execute();
 
       expect(mockFacade.restoreBackup).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('StatusCommand', () => {
+    it('facade.getStatus を呼ぶ', async () => {
+      const expected: ICommandResult = { success: true, data: { status: {} } };
+      vi.mocked(mockFacade.getStatus!).mockResolvedValue(expected);
+
+      const command = new StatusCommand(mockFacade as HostSwitchFacade);
+      const result = await command.execute();
+
+      expect(mockFacade.getStatus).toHaveBeenCalled();
+      expect(result).toBe(expected);
     });
   });
 });

--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -7,6 +7,7 @@ import type {
   IUserInterface,
   MessageType,
   ProfileInfo,
+  StatusInfo,
 } from '../../interfaces';
 
 export class CliUserInterface implements IUserInterface {
@@ -151,10 +152,44 @@ export class CliUserInterface implements IUserInterface {
           this.logger.info(`  ${backup.id}  (${when})`);
         });
       }
+    } else if (data && typeof data === 'object' && 'status' in data) {
+      this.displayStatus((data as { status: StatusInfo }).status);
     } else if (data && typeof data === 'object' && 'content' in data) {
       // Show profile command
       const contentData = data as { content: string };
       console.log(contentData.content);
+    }
+  }
+
+  private displayStatus(status: StatusInfo): void {
+    const profile = status.currentProfile ?? '(none)';
+    let state: string;
+    if (!status.currentProfile) {
+      state = 'no profile active';
+    } else if (status.modified) {
+      state = 'modified outside hostswitch';
+    } else {
+      state = 'in sync';
+    }
+
+    this.logger.info(`Current profile: ${profile}`);
+    this.logger.info(`Hosts file:      ${status.hostsPath}`);
+    this.logger.info(`Status:          ${state}`);
+    if (status.updatedAt) {
+      this.logger.info(`Last switched:   ${new Date(status.updatedAt).toLocaleString()}`);
+    }
+    if (status.latestBackup) {
+      const when = status.latestBackup.createdAt
+        ? status.latestBackup.createdAt.toLocaleString()
+        : 'unknown time';
+      this.logger.info(`Latest backup:   ${status.latestBackup.id} (${when})`);
+    }
+    if (status.modified) {
+      this.showMessage(
+        'Tip: run `hostswitch create <name> --from-current` to save the current hosts, ' +
+          'or `hostswitch switch <name>` to overwrite it.',
+        'warning'
+      );
     }
   }
 }

--- a/src/core/CurrentProfileManager.ts
+++ b/src/core/CurrentProfileManager.ts
@@ -32,6 +32,11 @@ export class CurrentProfileManager {
     }
   }
 
+  /** 最後に切り替えた日時。記録が無ければ null */
+  getUpdatedAt(): string | null {
+    return this.getCurrentProfileData()?.updatedAt ?? null;
+  }
+
   isHostsModified(): boolean {
     const currentData = this.getCurrentProfileData();
     if (!currentData || !currentData.checksum) {

--- a/src/core/HostSwitchService.ts
+++ b/src/core/HostSwitchService.ts
@@ -8,6 +8,7 @@ import type {
   ILogger,
   ProfileInfo,
   RestoreResult,
+  StatusInfo,
   SwitchOptions,
   SwitchResult,
 } from '../interfaces';
@@ -57,6 +58,18 @@ export class HostSwitchService {
 
   getBackups(): BackupInfo[] {
     return this.backupManager.listBackups();
+  }
+
+  getStatus(): StatusInfo {
+    const currentProfile = this.getCurrentProfile();
+    return {
+      currentProfile,
+      hostsPath: this.config.hostsPath,
+      // modified が意味を持つのは current がある時だけ
+      modified: currentProfile ? this.currentProfileManager.isHostsModified() : false,
+      updatedAt: this.currentProfileManager.getUpdatedAt(),
+      latestBackup: this.backupManager.listBackups()[0] ?? null,
+    };
   }
 
   /**

--- a/src/core/__tests__/HostSwitchService.test.ts
+++ b/src/core/__tests__/HostSwitchService.test.ts
@@ -428,4 +428,53 @@ describe('HostSwitchService - 統合テスト', () => {
       expect(backups[0].id).toBe('2026-08-05T14-32-10-123Z');
     });
   });
+
+  describe('getStatus()', () => {
+    it('current 未設定なら no profile として返す', () => {
+      const status = service.getStatus();
+
+      expect(status.currentProfile).toBeNull();
+      expect(status.modified).toBe(false);
+      expect(status.hostsPath).toBe(mocks.config.hostsPath);
+    });
+
+    it('current があり hosts が一致していれば modified=false', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'content');
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content');
+      // switch 相当: current.json を checksum つきで書く
+      const checksum = require('node:crypto').createHash('md5').update('content').digest('hex');
+      mocks.mockFileSystem.writeJsonSync(mocks.config.currentProfileFile, {
+        profile: 'dev',
+        checksum,
+        updatedAt: '2026-08-05T14:32:10.000Z',
+      });
+
+      const status = service.getStatus();
+
+      expect(status.currentProfile).toBe('dev');
+      expect(status.modified).toBe(false);
+      expect(status.updatedAt).toBe('2026-08-05T14:32:10.000Z');
+    });
+
+    it('hosts が外部で変わっていれば modified=true', () => {
+      mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'changed');
+      mocks.mockFileSystem.writeJsonSync(mocks.config.currentProfileFile, {
+        profile: 'dev',
+        checksum: 'stale',
+        updatedAt: '2026-08-05T14:32:10.000Z',
+      });
+
+      const status = service.getStatus();
+
+      expect(status.modified).toBe(true);
+    });
+
+    it('直近のバックアップを載せる', () => {
+      mocks.mockFileSystem.setFile(`${mocks.config.backupDir}/hosts_2026-08-07T09-15-00-000Z`, 'x');
+
+      const status = service.getStatus();
+
+      expect(status.latestBackup?.id).toBe('2026-08-07T09-15-00-000Z');
+    });
+  });
 });

--- a/src/hostswitch.ts
+++ b/src/hostswitch.ts
@@ -125,6 +125,16 @@ function parseCommands() {
       });
     });
 
+  // Status command
+  program
+    .command('status')
+    .description('Show the current profile and whether hosts drifted from it')
+    .action(async () => {
+      const ui = new CliUserInterface(logger, elevate);
+      const controller = new CliController(facade, ui);
+      await controller.executeCommand('status');
+    });
+
   // Backup list command
   program
     .command('backups')

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -108,6 +108,17 @@ export interface BackupInfo {
   createdAt: Date | null;
 }
 
+export interface StatusInfo {
+  currentProfile: string | null;
+  hostsPath: string;
+  /** current があり、その checksum と実ファイルが食い違っているか */
+  modified: boolean;
+  /** 最後に切り替えた日時。current が無ければ null */
+  updatedAt: string | null;
+  /** 直近のバックアップ。無ければ null */
+  latestBackup: BackupInfo | null;
+}
+
 export interface RestoreResult {
   success: boolean;
   message?: string;


### PR DESCRIPTION
## Summary

`isHostsModified()` は「hostswitch の外で hosts が編集されたか」を検出できましたが、それが見えるのは switch 実行時の警告1行だけでした。`hostswitch list` は current プロファイル名を出すものの、それが実ファイルと一致しているかは分からず、手で `/etc/hosts` を編集した後は表示と実態が食い違ったままになります。

## Related Issue

Closes #81

## 追加したコマンド

```bash
hostswitch status
```

出力:

```
Current profile: dev
Hosts file:      /etc/hosts
Status:          in sync
Last switched:   8/5/2026, 11:32:10 PM
Latest backup:   2026-08-05T14-32-10-123Z (8/5/2026, 11:32:10 PM)
```

hosts が外部で変更されていると `Status: modified outside hostswitch` になり、次のアクションを案内します:

```
Status:          modified outside hostswitch
...
Tip: run `hostswitch create <name> --from-current` to save the current hosts,
     or `hostswitch switch <name>` to overwrite it.
```

current 未設定時は:

```
Current profile: (none)
Status:          no profile active
```

## 設計

表示する情報の大半は **`current.json` が既に持っているデータ**（profile / checksum / updatedAt）から取れます。`modified` の判定は current がある時だけ意味を持つので、current 無しのときは常に `false` にしています。`StatusInfo` 型を新設し、Service → Facade → Command → 表示の既存の流れに載せました。

## テスト

- `HostSwitchService.getStatus()` — current 無し / in sync / modified / 直近バックアップ（+4ケース）
- `HostSwitchFacade.getStatus()`、`StatusCommand`

テストは **302 → 308件**。`npm run check` 通過。

## Checklist

- [x] `npm run check` passes locally
- [x] Tests added
- [x] Documentation updated (README.md / README.ja.md / CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
