### PR TITLE
ci: test on Node 20/22/24 and macOS, run coverage, audit prod deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,16 @@ on:
   pull_request:
 
 jobs:
-  check:
-    name: Lint, Build & Test
-    runs-on: ubuntu-latest
+  test:
+    name: Test (Node ${{ matrix.node }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # engines は Node >=20 を宣言しているので、その下限から現行までを回す。
+        # 主要ユーザー層の macOS も含める（Windows は #78 の postbuild 対応後に追加）
+        os: [ubuntu-latest, macos-latest]
+        node: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - name: Install dependencies
@@ -32,5 +39,43 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm run test:run
+      - name: Test with coverage
+        run: npm run test:coverage
+
+  audit:
+    name: Audit (production dependencies)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # hostswitch は sudo で動くので、本番依存の high 以上は落とす。
+      # dev 依存の脆弱性は Renovate と手動更新で追うため、ここでは対象外
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+  # ブランチ保護の必須チェック名 "Lint, Build & Test" を維持するための集約ゲート。
+  # matrix を必須チェックに直接指定すると組み合わせが増えるたびに保護設定を
+  # 更新する必要があるため、単一のゲートで受ける
+  check:
+    name: Lint, Build & Test
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Verify test matrix succeeded
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Test matrix did not succeed: ${{ needs.test.result }}"
+            exit 1
+          fi
+          echo "All matrix jobs passed."


### PR DESCRIPTION
## Summary

CI は `ubuntu-latest` + Node 24 の単一構成だけでした。`package.json` は `engines >= 20` を宣言し、主要ユーザー層は macOS なのに、**宣言した下限も主要プラットフォームも実際には検証されておらず**、カバレッジも取っていませんでした。

## Related Issue

Refs #86

## 変更

**test job を matrix 化**: `{ubuntu-latest, macos-latest} × {Node 20, 22, 24}` の6組で lint / format / build / `test:coverage` を回します。

**Windows は含めていません** — #78 の `postbuild` の `chmod` が Windows でビルドを壊すためです。そちらの対応後に追加するのが順序として正しいので、CI コメントにもその旨を書いています。

**audit job を追加**: `npm audit --omit=dev --audit-level=high`。hostswitch は sudo で動くので本番依存の high 以上は拾いたい（#74 がまさにこれでした）。

## ブランチ保護を壊さない工夫

`main` の必須チェックは **"Lint, Build & Test" という名前**を指しています。matrix job をそのまま必須チェックにすると、**組み合わせが変わるたびにブランチ保護の設定を更新する必要**が出ます。

そこで、**"Lint, Build & Test" という同名の集約ゲート job** を1つ置き、matrix の結果を `needs` で受けるだけにしました。これにより**ブランチ保護の設定は一切変更不要**です（既存の必須チェック名がそのまま生き続けます）。

## audit を必須ゲートに含めていない理由

audit job は独立させ、**必須ゲート（check）には含めていません**。脆弱性 advisory は依存側の都合で突然増えるため、無関係なPRが監査の失敗でマージ不能になるのを避ける判断です。新しい脆弱性が出れば PR 上で赤く見えるので気づけます。**ブロックしたい場合は、リポジトリ設定で `Audit (production dependencies)` を必須チェックに追加**してください。

## 補足: deploy-docs.yml の Node 20

#86 で触れられている「deploy-docs だけ Node 20」は website 側のビルド要件に関わるため、このPRでは触っていません。揃えるかどうかは別途ご判断ください。

## 確認

- `npm run test:coverage` がローカルで通ることを確認済み（CI の新ステップと同じ）
- CI YAML の構文を検証済み

CI 上で6組 + audit + gate が動くのは、このPRがマージされて初めて確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
