### PR TITLE
test: type-check tests, and gate coverage with thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      - name: Type check (including tests)
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",
     "format": "biome format --write src",
     "format:check": "biome format src",
-    "check": "npm run lint && npm run format:check && npm run test:run"
+    "check": "npm run lint && npm run format:check && npm run typecheck && npm run test:run"
   },
   "keywords": [
     "hosts",

--- a/src/cli/__tests__/HostSwitchFacade.test.ts
+++ b/src/cli/__tests__/HostSwitchFacade.test.ts
@@ -3,7 +3,6 @@ import type { HostSwitchService } from '../../core/HostSwitchService';
 import type {
   CreateProfileResult,
   DeleteResult,
-  ILogger,
   IPermissionChecker,
   IProcessManager,
   ProfileContentResult,
@@ -32,7 +31,6 @@ describe('HostSwitchFacade', () => {
     restoreBackup: ReturnType<typeof vi.fn>;
     getStatus: ReturnType<typeof vi.fn>;
   };
-  let _mockLogger: ILogger;
   let mockProcessManager: IProcessManager;
   let mockPermissionChecker: IPermissionChecker;
 
@@ -55,17 +53,6 @@ describe('HostSwitchFacade', () => {
       getStatus: vi.fn(),
     };
 
-    _mockLogger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      warning: vi.fn(),
-      error: vi.fn(),
-      success: vi.fn(),
-      dim: vi.fn(),
-      bold: vi.fn(),
-      debug: vi.fn(),
-    };
-
     mockProcessManager = {
       executeEditor: vi.fn(),
       openEditor: vi.fn(),
@@ -80,7 +67,7 @@ describe('HostSwitchFacade', () => {
     };
 
     facade = new HostSwitchFacade(
-      mockService as HostSwitchService,
+      mockService as unknown as HostSwitchService,
       mockProcessManager,
       mockPermissionChecker
     );

--- a/src/cli/__tests__/Integration.test.ts
+++ b/src/cli/__tests__/Integration.test.ts
@@ -45,6 +45,7 @@ describe('Integration Tests', () => {
       readFileSync: vi.fn(),
       writeFileSync: vi.fn(),
       copySync: vi.fn(),
+      renameSync: vi.fn(),
       unlinkSync: vi.fn(),
       existsSync: vi.fn().mockReturnValue(true),
       ensureDirSync: vi.fn(),

--- a/src/cli/ui/__tests__/AutoSudo.test.ts
+++ b/src/cli/ui/__tests__/AutoSudo.test.ts
@@ -20,6 +20,7 @@ describe('Auto-Sudo Functionality', () => {
       success: vi.fn(),
       dim: vi.fn(),
       bold: vi.fn(),
+      debug: vi.fn(),
     };
 
     mockElevate = vi.fn().mockResolvedValue({ success: true, message: 'Completed successfully' });

--- a/src/cli/ui/__tests__/UserInterface.test.ts
+++ b/src/cli/ui/__tests__/UserInterface.test.ts
@@ -22,7 +22,7 @@ describe('User Interface Classes', () => {
       elevate: vi.fn(),
       getCurrentProfile: vi.fn(),
       getDeletableProfiles: vi.fn(),
-    } as HostSwitchFacade;
+    } as unknown as HostSwitchFacade;
 
     mockLogger = {
       info: vi.fn(),

--- a/src/core/__tests__/CurrentProfileManager.test.ts
+++ b/src/core/__tests__/CurrentProfileManager.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import type { ProfileData } from '../../interfaces';
 import { CurrentProfileManager } from '../CurrentProfileManager';
 import { createTestMocks, setCurrentProfile } from './setup';
 
@@ -46,7 +47,9 @@ describe('CurrentProfileManager', () => {
 
       currentProfileManager.setCurrentProfile('dev');
 
-      const currentData = mocks.mockFileSystem.readJsonSync(mocks.config.currentProfileFile);
+      const currentData = mocks.mockFileSystem.readJsonSync<ProfileData>(
+        mocks.config.currentProfileFile
+      );
       expect(currentData.profile).toBe('dev');
       expect(currentData.checksum).toBeDefined();
       expect(currentData.updatedAt).toBeDefined();
@@ -58,20 +61,22 @@ describe('CurrentProfileManager', () => {
 
       currentProfileManager.setCurrentProfile('dev');
 
-      const currentData = mocks.mockFileSystem.readJsonSync(mocks.config.currentProfileFile);
+      const currentData = mocks.mockFileSystem.readJsonSync<ProfileData>(
+        mocks.config.currentProfileFile
+      );
       expect(currentData.checksum).toBeDefined();
       expect(typeof currentData.checksum).toBe('string');
-      expect(currentData.checksum.length).toBeGreaterThan(0);
+      expect((currentData.checksum as string).length).toBeGreaterThan(0);
     });
 
     it('異なるhostsファイル内容では異なるチェックサム', () => {
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content1');
       currentProfileManager.setCurrentProfile('dev1');
-      const data1 = mocks.mockFileSystem.readJsonSync(mocks.config.currentProfileFile);
+      const data1 = mocks.mockFileSystem.readJsonSync<ProfileData>(mocks.config.currentProfileFile);
 
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content2');
       currentProfileManager.setCurrentProfile('dev2');
-      const data2 = mocks.mockFileSystem.readJsonSync(mocks.config.currentProfileFile);
+      const data2 = mocks.mockFileSystem.readJsonSync<ProfileData>(mocks.config.currentProfileFile);
 
       expect(data1.checksum).not.toBe(data2.checksum);
     });

--- a/src/core/__tests__/UpdateChecker.test.ts
+++ b/src/core/__tests__/UpdateChecker.test.ts
@@ -7,7 +7,7 @@ const pkg = { name: 'hostswitch', version: '1.2.13' };
 /** update-notifier の呼び出しを記録するだけのスタブ */
 function createChecker(opts: { env?: NodeJS.ProcessEnv; euid?: number | undefined } = {}) {
   const notify = vi.fn();
-  const notifier = vi.fn(() => ({ notify }));
+  const notifier = vi.fn((_opts: unknown) => ({ notify }));
   const checker = new UpdateChecker(pkg, {
     env: opts.env ?? {},
     getEuid: () => opts.euid,
@@ -70,7 +70,7 @@ describe('UpdateChecker', () => {
 
       checker.check('msg');
 
-      const arg = notifier.mock.calls[0][0] as { updateCheckInterval: number };
+      const arg = notifier.mock.calls[0]?.[0] as { updateCheckInterval: number };
       expect(arg.updateCheckInterval).toBeGreaterThan(0);
     });
 

--- a/src/infrastructure/__tests__/FileSystemAdapter.test.ts
+++ b/src/infrastructure/__tests__/FileSystemAdapter.test.ts
@@ -17,11 +17,13 @@ vi.mock('fs-extra', () => ({
 
 describe('FileSystemAdapter', () => {
   let adapter: FileSystemAdapter;
-  let mockFs: typeof import('fs-extra');
+  let mockFs: {
+    [K in keyof typeof import('fs-extra')]: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     adapter = new FileSystemAdapter();
-    mockFs = await vi.importMock('fs-extra');
+    mockFs = (await vi.importMock('fs-extra')) as typeof mockFs;
     vi.clearAllMocks();
   });
 

--- a/src/infrastructure/__tests__/PermissionChecker.test.ts
+++ b/src/infrastructure/__tests__/PermissionChecker.test.ts
@@ -18,12 +18,20 @@ vi.mock('fs-extra', () => ({
 describe('PermissionChecker', () => {
   let permissionChecker: PermissionChecker;
   let mockSpawn: ReturnType<typeof vi.mocked<typeof spawn>>;
-  let mockFs: typeof import('fs-extra');
+  let mockFs: {
+    access: ReturnType<typeof vi.fn>;
+    accessSync: ReturnType<typeof vi.fn>;
+    readFile: ReturnType<typeof vi.fn>;
+    writeFile: ReturnType<typeof vi.fn>;
+    copy: ReturnType<typeof vi.fn>;
+    unlink: ReturnType<typeof vi.fn>;
+    constants: { W_OK: number };
+  };
 
   beforeEach(async () => {
     permissionChecker = new PermissionChecker();
     mockSpawn = vi.mocked(spawn);
-    mockFs = await vi.importMock('fs-extra');
+    mockFs = (await vi.importMock('fs-extra')) as typeof mockFs;
 
     // デフォルトのモック設定をリセット
     vi.clearAllMocks();

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,24 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts']
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+        // 型定義のみで実行コードがない
+        'src/interfaces/**',
+        // テスト用モック
+        'src/__mocks__/**',
+        // 依存の組み立て（結線）のみ。E2E でしか意味のあるカバレッジにならない
+        'src/hostswitch.ts',
+      ],
+      // 現状値（lines/statements 83%, branches 84%, functions 91%）から
+      // 少し下に置く。ここを割ったら CI が落ちる
+      thresholds: {
+        lines: 80,
+        statements: 80,
+        branches: 78,
+        functions: 85,
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary

#83 のうち、**一番効く2点**を対応します。テストの型チェックと、カバレッジの計測対象・閾値です。

## Related Issue

Refs #83

## 1. テストが型チェックされていなかった

`tsconfig.json` の `exclude` に `**/__tests__` と `**/*.test.ts` が入っているため、`tsc` はテストを一切見ていませんでした。これが実害を出しています — **#97 でコンストラクタ引数を変えた際、テストが古い呼び方のままでもビルドは緑**で、実行時エラーで初めて気づきました。

対応:

- `tsconfig.test.json`（本体設定を extends し、テストを含める）を追加
- `typecheck` スクリプト（`tsc --noEmit && tsc -p tsconfig.test.json`）を追加し、**`npm run check` と CI の両方に組み込み**
- これで炙り出された **約30件の型エラーを解消**:
  - `unknown` を経由しないモックの直接キャスト（`as X` → `as unknown as X`）
  - `fs-extra` のモックが実体型のせいで vitest のモックメソッドを隠していた箇所
  - 型引数なしの `readJsonSync` 呼び出し
  - 新しく増えたインターフェースメンバを欠いたモック（`renameSync`、`debug`）

**テストの挙動は変えていません**（308件のまま全パス）。型の付け方だけを直しています。

## 2. カバレッジの計測対象と閾値

計測すべきでないものを除外しました:

- `src/interfaces/**`（型定義のみで実行コードなし）
- `src/__mocks__/**`（テスト用モック）
- `src/hostswitch.ts`（DI の結線のみ。E2E でしか意味のあるカバレッジにならない）

除外後の数字は lines/statements **83%**、branches **84%**、functions **91%** です。ここから少し下に**閾値**を置きました（lines/statements 80 / branches 78 / functions 85）。**割ると CI が落ちます**。カバレッジは #100 で既に CI で実行しているので、閾値もそこで強制されます。

## #83 の残り

このPRで「モックがカバレッジ対象」「閾値がない」「テストの型崩れに気づけない」は解消します。残るのは:

- **`InteractiveUserInterface` のカバレッジ向上**（現状 64%）— テストは存在しますが手薄です
- `src/__tests__/` 空ディレクトリ — git は空ディレクトリを追跡しないため実害はなく、今回は放置しています

これらは #83 に残す形にします。

## Checklist

- [x] `npm run check` passes locally（typecheck を含む）
- [x] Tests type-check clean
- [x] カバレッジ閾値を設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
