### PR TITLE
feat: confirm delete interactively, and keep the interactive menu open

### DIFF
--- a/src/cli/CliController.ts
+++ b/src/cli/CliController.ts
@@ -90,7 +90,7 @@ export class CliController {
         if (!params.name) {
           throw new Error('Profile name is required for delete command');
         }
-        return new DeleteProfileCommand(this.facade, params.name, params.force || false);
+        return new DeleteProfileCommand(this.facade, params.name, params.force || false, this.ui);
 
       default:
         throw new Error(`Unknown command type: ${type}`);

--- a/src/cli/__tests__/Integration.test.ts
+++ b/src/cli/__tests__/Integration.test.ts
@@ -291,12 +291,19 @@ describe('Integration Tests', () => {
       ]);
     });
 
-    it('should throw errors for unsupported operations in CLI UI', async () => {
-      await expect(cliUI.promptConfirm('Are you sure?')).rejects.toThrow(
-        'not supported in CLI mode'
-      );
+    it('CLI UI は select/input を非対話としてエラーにする', async () => {
       await expect(cliUI.promptSelect('Choose:', [])).rejects.toThrow('not supported in CLI mode');
       await expect(cliUI.promptInput('Enter:')).rejects.toThrow('not supported in CLI mode');
+    });
+
+    it('CLI UI は TTY が無ければ確認プロンプトを出せない', async () => {
+      const original = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+      expect(cliUI.canConfirmInteractively()).toBe(false);
+      await expect(cliUI.promptConfirm('Are you sure?')).rejects.toThrow('--force');
+
+      Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true });
     });
   });
 });

--- a/src/cli/commands/DeleteProfileCommand.ts
+++ b/src/cli/commands/DeleteProfileCommand.ts
@@ -1,14 +1,30 @@
-import type { ICommand, ICommandResult } from '../../interfaces';
+import type { ICommand, ICommandResult, IUserInterface } from '../../interfaces';
 import type { HostSwitchFacade } from '../HostSwitchFacade';
 
 export class DeleteProfileCommand implements ICommand {
   constructor(
     private facade: HostSwitchFacade,
     private profileName: string,
-    private force: boolean = false
+    private force: boolean = false,
+    private ui?: IUserInterface
   ) {}
 
   async execute(): Promise<ICommandResult> {
-    return this.facade.deleteProfile(this.profileName, this.force);
+    if (this.force) {
+      return this.facade.deleteProfile(this.profileName, true);
+    }
+
+    // TTY があれば確認プロンプトを出し、その場で削除まで済ませる。
+    // --force はそのプロンプトを飛ばすフラグとして働く。
+    if (this.ui?.canConfirmInteractively()) {
+      const confirmed = await this.ui.promptConfirm(`Delete profile "${this.profileName}"?`);
+      if (!confirmed) {
+        return { success: true, message: 'Deletion cancelled' };
+      }
+      return this.facade.deleteProfile(this.profileName, true);
+    }
+
+    // 非対話（CI・パイプ）では確認できないので --force を要求する
+    return this.facade.deleteProfile(this.profileName, false);
   }
 }

--- a/src/cli/commands/__tests__/Commands.test.ts
+++ b/src/cli/commands/__tests__/Commands.test.ts
@@ -171,4 +171,63 @@ describe('Command Classes', () => {
       expect(result).toBe(expected);
     });
   });
+
+  describe('DeleteProfileCommand', () => {
+    const makeUi = (canConfirm: boolean, confirmValue = true) =>
+      ({
+        canConfirmInteractively: vi.fn().mockReturnValue(canConfirm),
+        promptConfirm: vi.fn().mockResolvedValue(confirmValue),
+        showMessage: vi.fn(),
+        promptSelect: vi.fn(),
+        promptInput: vi.fn(),
+        handleCommandResult: vi.fn(),
+      }) as unknown as import('../../../interfaces').IUserInterface & {
+        canConfirmInteractively: ReturnType<typeof vi.fn>;
+        promptConfirm: ReturnType<typeof vi.fn>;
+      };
+
+    it('--force ならそのまま削除する', async () => {
+      vi.mocked(mockFacade.deleteProfile!).mockResolvedValue({ success: true });
+
+      const command = new DeleteProfileCommand(mockFacade as HostSwitchFacade, 'dev', true);
+      await command.execute();
+
+      expect(mockFacade.deleteProfile).toHaveBeenCalledWith('dev', true);
+    });
+
+    it('TTY があれば確認して Yes なら削除する', async () => {
+      vi.mocked(mockFacade.deleteProfile!).mockResolvedValue({ success: true });
+      const ui = makeUi(true, true);
+
+      const command = new DeleteProfileCommand(mockFacade as HostSwitchFacade, 'dev', false, ui);
+      await command.execute();
+
+      expect(ui.promptConfirm).toHaveBeenCalled();
+      expect(mockFacade.deleteProfile).toHaveBeenCalledWith('dev', true);
+    });
+
+    it('確認で No なら削除しない', async () => {
+      const ui = makeUi(true, false);
+
+      const command = new DeleteProfileCommand(mockFacade as HostSwitchFacade, 'dev', false, ui);
+      const result = await command.execute();
+
+      expect(mockFacade.deleteProfile).not.toHaveBeenCalled();
+      expect(result.message).toContain('cancelled');
+    });
+
+    it('非TTYでは確認せず force=false で委譲する', async () => {
+      vi.mocked(mockFacade.deleteProfile!).mockResolvedValue({
+        success: false,
+        requiresConfirmation: true,
+      });
+      const ui = makeUi(false);
+
+      const command = new DeleteProfileCommand(mockFacade as HostSwitchFacade, 'dev', false, ui);
+      await command.execute();
+
+      expect(ui.promptConfirm).not.toHaveBeenCalled();
+      expect(mockFacade.deleteProfile).toHaveBeenCalledWith('dev', false);
+    });
+  });
 });

--- a/src/cli/ui/CliUserInterface.ts
+++ b/src/cli/ui/CliUserInterface.ts
@@ -1,3 +1,4 @@
+import inquirer from 'inquirer';
 import type {
   BackupInfo,
   Choice,
@@ -34,10 +35,19 @@ export class CliUserInterface implements IUserInterface {
     }
   }
 
-  async promptConfirm(_message: string): Promise<boolean> {
-    throw new Error(
-      'Confirmation prompts are not supported in CLI mode. Use command line arguments instead.'
-    );
+  canConfirmInteractively(): boolean {
+    // TTY が無い（CI・パイプ）場合は対話できないので false
+    return Boolean(process.stdin.isTTY);
+  }
+
+  async promptConfirm(message: string): Promise<boolean> {
+    if (!this.canConfirmInteractively()) {
+      throw new Error('Confirmation prompts are not supported without a TTY. Use --force instead.');
+    }
+    const answer = await inquirer.prompt([
+      { type: 'confirm', name: 'confirmed', message, default: false },
+    ]);
+    return answer.confirmed;
   }
 
   async promptSelect<T>(_message: string, _choices: Choice<T>[]): Promise<T> {

--- a/src/cli/ui/InteractiveUserInterface.ts
+++ b/src/cli/ui/InteractiveUserInterface.ts
@@ -32,6 +32,10 @@ export class InteractiveUserInterface implements IUserInterface {
     }
   }
 
+  canConfirmInteractively(): boolean {
+    return true;
+  }
+
   async promptConfirm(message: string): Promise<boolean> {
     const answer = await inquirer.prompt([
       {
@@ -138,25 +142,33 @@ export class InteractiveUserInterface implements IUserInterface {
     switch (action) {
       case 'list':
         await this.handleListProfiles();
-        return false; // Continue interactive mode
+        return false;
       case 'switch':
+        // switch は sudo で自分自身を再実行してプロセスが置き換わるため、
+        // ここで戻ってきてもメニューを続ける意味がない。終了する
         await this.handleSwitchProfile();
-        return true; // Exit after action
+        return true;
       case 'create':
         await this.handleCreateProfile();
-        return true; // Exit after action
+        return false;
       case 'edit':
         await this.handleEditProfile();
-        return true; // Exit after action
+        return false;
       case 'show':
         await this.handleShowProfile();
-        return true; // Exit after action
+        // 表示内容がメニューで流れないよう、続行前に一拍置く
+        await this.waitForEnter();
+        return false;
       case 'delete':
         await this.handleDeleteProfile();
-        return true; // Exit after action
+        return false;
       default:
         return false;
     }
+  }
+
+  private async waitForEnter(): Promise<void> {
+    await this.promptInput('Press Enter to continue');
   }
 
   private async handleListProfiles(): Promise<void> {
@@ -294,7 +306,9 @@ export class InteractiveUserInterface implements IUserInterface {
     const confirmed = await this.promptConfirm(`Are you sure you want to delete "${profileName}"?`);
 
     if (confirmed) {
-      const result = await this.facade.deleteProfile(profileName);
+      // ここで既に確認済みなので force=true で実行する。false のままだと
+      // Facade が requiresConfirmation を返し、確認したのに削除されない
+      const result = await this.facade.deleteProfile(profileName, true);
       if (result.success) {
         this.showMessage(result.message || 'Profile deleted successfully', 'success');
       } else {

--- a/src/cli/ui/__tests__/UserInterface.test.ts
+++ b/src/cli/ui/__tests__/UserInterface.test.ts
@@ -67,8 +67,8 @@ describe('User Interface Classes', () => {
     });
 
     describe('interactive methods', () => {
-      it('should throw error for promptConfirm', async () => {
-        await expect(cliUI.promptConfirm('Confirm?')).rejects.toThrow('not supported in CLI mode');
+      it('TTY が無ければ promptConfirm はエラー（--force を促す）', async () => {
+        await expect(cliUI.promptConfirm('Confirm?')).rejects.toThrow('--force');
       });
 
       it('should throw error for promptSelect', async () => {
@@ -160,6 +160,10 @@ describe('User Interface Classes', () => {
 
     beforeEach(() => {
       interactiveUI = new InteractiveUserInterface(mockFacade, mockLogger);
+      // run() はメニューが 'exit' を返すまで回り続ける。モックを積み忘れると
+      // 無限ループ→OOM でプロセスごと落ちるため、既定値を 'exit' にしておく。
+      // 各テストは mockResolvedValueOnce を積み、消費し切ると自動で抜ける（#106）
+      vi.mocked(inquirer.prompt).mockResolvedValue({ selected: 'exit' });
     });
 
     describe('showMessage', () => {
@@ -274,7 +278,8 @@ describe('User Interface Classes', () => {
 
         await interactiveUI.run();
 
-        expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+        // edit(2) の後もメニューに戻り、既定の exit で抜ける(3回目)
+        expect(inquirer.prompt).toHaveBeenCalledTimes(3);
         expect(mockFacade.switchProfile).not.toHaveBeenCalled();
       });
     });
@@ -464,6 +469,58 @@ describe('User Interface Classes', () => {
         await interactiveUI.handleCommandResult(result);
 
         expect(mockFacade.elevate).toHaveBeenCalledWith(['switch', 'complex profile name']);
+      });
+    });
+
+    describe('run() - メニュー継続（#87）', () => {
+      it('list の後もメニューに戻る（1操作で終了しない）', async () => {
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: { profiles: [{ name: 'dev', isCurrent: false }] },
+        });
+        // list → メニュー(既定 exit)。list が実行され、その後メニューに戻る
+        vi.mocked(inquirer.prompt).mockResolvedValueOnce({ selected: 'list' });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.listProfiles).toHaveBeenCalled();
+        // list(1) の後、既定の exit を引くメニュー(2)が出る = 1操作で終了していない
+        expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('run() - delete（#87）', () => {
+      it('確認して Yes なら force=true で削除する', async () => {
+        // 以前は force を渡さず、確認したのに削除されないバグがあった
+        vi.mocked(mockFacade.getDeletableProfiles).mockReturnValue([
+          { name: 'dev', isCurrent: false },
+        ]);
+        vi.mocked(mockFacade.deleteProfile).mockResolvedValue({
+          success: true,
+          message: 'Profile "dev" deleted successfully',
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'delete' })
+          .mockResolvedValueOnce({ selected: 'dev' })
+          .mockResolvedValueOnce({ confirmed: true });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.deleteProfile).toHaveBeenCalledWith('dev', true);
+      });
+
+      it('確認で No なら削除しない', async () => {
+        vi.mocked(mockFacade.getDeletableProfiles).mockReturnValue([
+          { name: 'dev', isCurrent: false },
+        ]);
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'delete' })
+          .mockResolvedValueOnce({ selected: 'dev' })
+          .mockResolvedValueOnce({ confirmed: false });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.deleteProfile).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -175,6 +175,8 @@ export interface Choice<T> {
 
 export interface IUserInterface {
   showMessage(message: string, type?: MessageType): void;
+  /** 対話的な確認プロンプトを出せるか（TTY があるか等） */
+  canConfirmInteractively(): boolean;
   promptConfirm(message: string): Promise<boolean>;
   promptSelect<T>(message: string, choices: Choice<T>[]): Promise<T>;
   promptInput(message: string, validator?: (input: string) => boolean | string): Promise<string>;


### PR DESCRIPTION
## Summary

#87 の2つの UX 問題を対応し、あわせて発見した実バグも直します。

## Related Issue

Closes #87

## 1. `delete` が2回実行を強要していた

`hostswitch delete foo` は確認プロンプトを出さず「`--force` を付けて打ち直せ」と言うだけでした。しかも打ち直すと確認が完全にスキップされるので、「確認を求める」目的も達成できていませんでした。

変更後:

- **TTY があれば確認プロンプトを出し、Yes でその場で削除**（1回で済む）
- `--force` は「そのプロンプトを飛ばす」フラグ本来の意味に
- **非TTY（CI・パイプ）では従来どおり `--force` 必須**（安全側）

`CliUserInterface.promptConfirm` は常に throw する実装でしたが、TTY があれば inquirer で確認するようにしました。`IUserInterface` に `canConfirmInteractively()` を追加し、delete コマンドが TTY の有無で分岐します。

```
# 非TTY（パイプ）
$ echo "" | hostswitch delete victim
This operation requires confirmation. Add --force flag to proceed without confirmation.

# --force
$ hostswitch delete victim --force
Profile "victim" deleted successfully
```

## 2. インタラクティブモードが1操作ごとに終了していた

`hostswitch`（引数なし）のメニューは、`list` 以外のどのアクションを選んでも1回で終了していました。「作る → 中身を見る → 消す」のような連続操作ができませんでした。

変更後:

- **switch 以外のアクションはメニューに戻る**。`Exit` を選ぶまで続けられる
- **switch だけは終了**（sudo で自分自身を再実行しプロセスが置き換わるため、戻っても意味がない）
- **show の後は Enter 待ち**を挟み、表示内容が再描画メニューで流れないように

## 3. 実バグ: インタラクティブ delete が確認しても消えなかった

作業中に発見しました。インタラクティブモードで削除を選び確認プロンプトで **Yes と答えても、`deleteProfile` を force なしで呼んでいた**ため、Facade が `requiresConfirmation` を返して**実際には削除されていませんでした**。確認したのに何も起きない二重の壊れ方です。`force: true` を渡すよう修正しました。

## テストの注意（#106 に切り出し）

`InteractiveUserInterface.run()` はメニューが `'exit'` を返すまで回ります。`run()` のテストは inquirer モックの既定値を `'exit'` にしたので、**モックの積み忘れが無限ループ→OOM でプロセスを落とす代わりに、安全にループを抜ける**ようにしました。この構造的な脆さは #106 に切り出してあります。

## テスト

- `DeleteProfileCommand` — force / TTY確認Yes / No / 非TTY委譲（+4）
- `InteractiveUserInterface.run()` — メニュー継続 / delete確認Yes(force=true) / No（+3）
- 既存の promptConfirm 期待を新仕様（`--force` を促す）に更新

テストは **308 → 316件**。`npm run check`（lint + format + typecheck + test）通過。

## Checklist

- [x] `npm run check` passes locally
- [x] Tests added
- [x] Documentation updated — CLI の挙動変更のみで、コマンド自体は不変のため README 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
