### PR TITLE
Migrate hosts drift checksum from MD5 to SHA-256

### DIFF
--- a/src/core/CurrentProfileManager.ts
+++ b/src/core/CurrentProfileManager.ts
@@ -60,7 +60,7 @@ export class CurrentProfileManager {
   private getHostsChecksum(): string | null {
     try {
       const content = this.fileSystem.readFileSync(this.config.hostsPath);
-      return crypto.createHash('md5').update(content).digest('hex');
+      return crypto.createHash('sha256').update(content).digest('hex');
     } catch (_err) {
       return null;
     }

--- a/src/core/__tests__/HostSwitchService.test.ts
+++ b/src/core/__tests__/HostSwitchService.test.ts
@@ -442,7 +442,7 @@ describe('HostSwitchService - 統合テスト', () => {
       mocks.mockFileSystem.setFile(`${mocks.config.profilesDir}/dev.hosts`, 'content');
       mocks.mockFileSystem.setFile(mocks.config.hostsPath, 'content');
       // switch 相当: current.json を checksum つきで書く
-      const checksum = require('node:crypto').createHash('md5').update('content').digest('hex');
+      const checksum = require('node:crypto').createHash('sha256').update('content').digest('hex');
       mocks.mockFileSystem.writeJsonSync(mocks.config.currentProfileFile, {
         profile: 'dev',
         checksum,


### PR DESCRIPTION
## Summary

`CurrentProfileManager` used MD5 for hosts drift detection. Switched to SHA-256.

Existing `~/.hostswitch/current.json` MD5 checksums will not match once; the next `switch` rewrites with SHA-256. No data loss.

## Test plan

- [x] `md5` → `sha256` in manager + tests
- [ ] `npm test` if available in CI

Fixes #104