### PR TITLE
chore: lint and format the root config files, not just src/

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,55 +1,55 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
-	},
-	"files": {
-		"ignoreUnknown": false,
-		"includes": ["src/**/*.ts", "src/**/*.js", "*.json"]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "space",
-		"indentWidth": 2,
-		"lineWidth": 100
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"complexity": {
-				"noExcessiveCognitiveComplexity": "error"
-			},
-			"style": {
-				"noNonNullAssertion": "off",
-				"useConsistentArrayType": "error"
-			},
-			"suspicious": {
-				"noExplicitAny": "warn"
-			}
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single",
-			"trailingCommas": "es5",
-			"semicolons": "always"
-		}
-	},
-	"json": {
-		"formatter": {
-			"indentStyle": "space",
-			"indentWidth": 2
-		}
-	},
-	"assist": {
-		"enabled": true,
-		"actions": {
-			"source": {
-				"organizeImports": "on"
-			}
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/**/*.ts", "src/**/*.js", "*.ts", "*.json", "!package-lock.json"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useConsistentArrayType": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentStyle": "space",
+      "indentWidth": 2
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
-    "lint": "biome check src",
-    "lint:fix": "biome check --write src",
-    "format": "biome format --write src",
-    "format:check": "biome format src",
+    "lint": "biome check",
+    "lint:fix": "biome check --write",
+    "format": "biome format --write",
+    "format:check": "biome format",
     "check": "npm run lint && npm run format:check && npm run typecheck && npm run test:run"
   },
   "keywords": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,14 +23,6 @@
     "experimentalDecorators": true,
     "types": ["node"]
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "test",
-    "**/__tests__",
-    "**/*.test.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/__tests__", "**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
@@ -33,7 +33,7 @@ export default defineConfig({
         statements: 80,
         branches: 78,
         functions: 85,
-      }
-    }
-  }
-})
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

`npm run lint` は `biome check src` で、**CLI 引数の `src` がスコープを固定**していたため、`biome.json` の `files.includes` が実質無視されていました。結果、ルートの設定ファイル（特に `vite.config.ts`）は lint / format されていませんでした。

## Related Issue

Closes #105

## 変更

1. **スクリプトから `src` 引数を外す** — lint / lint:fix / format / format:check が `biome.json` の `includes` に従うように
2. **`includes` を拡張** — `src/**` に加えてルートの `*.ts` / `*.json` を対象に、生成物の `package-lock.json` は除外

```jsonc
"includes": ["src/**/*.ts", "src/**/*.js", "*.ts", "*.json", "!package-lock.json"]
```

`useIgnoreFile: true` が `node_modules`/`dist`/`coverage` を除外し、単一 `*` グロブは `website/` の中まで届かないので、生成物・vendored なものは対象に入りません（biome がチェックするのは **51 ファイル**）。

## 影響

新しく対象になった `biome.json` / `renovate.json` / `tsconfig.json` / `vite.config.ts` が、プロジェクトの2スペース整形に揃いました。

- **lint ルールは一切変更していません**（`recommended`/`error`/`off`/`warn` は全て不変）。biome.json の diff が大きいのは、biome 自身が biome.json をタブ→スペースに整形したためです
- **src ファイルの挙動は不変**。残る2つの src 指摘（`useTemplate` / `useOptionalChain`）は biome が「unsafe（挙動が変わりうる）」として人間の判断に残す提案で、**このPR以前から存在する非ブロッキングの info/warning** です

なお `biome.json` に `linter.rules.recommended` の deprecation 警告が出ますが、これも**以前から存在する**もので（biome は常に biome.json を読むため）、ルール適用に影響するので今回は触っていません（別途対応可）。

## 確認

`npm run check`（lint + format:check + typecheck + test、**316 tests**）通過。

## Checklist

- [x] `npm run check` passes locally
- [x] ルートの TS/JSON 設定ファイルが lint/format 対象になっている
- [x] `node_modules` / `dist` / `coverage` / `website` が対象に入っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
