### PR TITLE
ci: fail the release if the tag and package.json version disagree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,20 @@ jobs:
           node-version: 24
           cache: npm
 
+      # リリースタグは npm publish されるバージョンと一致していなければならない。
+      # バージョン更新コミットを挟まずにタグだけ打つと、中身が前バージョンのまま
+      # publish され、npm から分かりにくいエラーで落ちる（#102）。ここで先に弾く。
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag v$TAG does not match package.json version $PKG."
+            echo "Did you forget to run 'npm version' before tagging?"
+            exit 1
+          fi
+          echo "Tag v$TAG matches package.json version $PKG."
+
       - name: Install dependencies
         run: npm ci
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,25 @@ insurance while you're testing changes to the switching logic itself.
 - Make sure `npm run check` passes.
 - Update relevant documentation (README, docs site under `website/`, etc.)
   if behavior changes.
+
+## Releasing (maintainers)
+
+Releases publish to npm via `.github/workflows/publish.yml`, which runs
+when a **GitHub Release** is published. The published version comes from
+`package.json`, **not** from the tag name — so the tag and `package.json`
+must agree. Use `npm version` to keep them in sync rather than tagging by
+hand:
+
+```bash
+git checkout main && git pull --ff-only origin main
+npm version patch            # bumps package.json, commits "x.y.z", tags vx.y.z
+git push origin main --follow-tags
+gh release create vx.y.z --generate-notes   # this triggers the publish workflow
+```
+
+Tagging a commit that still has the previous `package.json` version (for
+example running `git tag` without `npm version`) publishes the old version
+and npm rejects it with `cannot publish over the previously published
+versions`. The publish workflow now fails fast with a clear message when
+the tag and `package.json` disagree, but the correct fix is always to bump
+the version with `npm version`.


### PR DESCRIPTION
## Summary

v1.2.14 のリリースが失敗した件（package.json が 1.2.13 のままのコミットにタグを打ってしまい、npm が `cannot publish over the previously published versions` で拒否）の再発防止です。

## Related Issue

Closes #102

## 変更

**publish.yml にタグ⇔version の一致検証を追加**。Setup Node の直後、重い install/build/test の**前**に検証し、不一致なら明確なメッセージで即座に落とします。

```yaml
- name: Verify tag matches package.json version
  run: |
    TAG="${GITHUB_REF_NAME#v}"
    PKG="$(node -p "require('./package.json').version")"
    if [ "$TAG" != "$PKG" ]; then
      echo "::error::Release tag v$TAG does not match package.json version $PKG."
      echo "Did you forget to run 'npm version' before tagging?"
      exit 1
    fi
```

これで、npm の分かりにくいエラーの代わりに「タグと package.json がズレている、`npm version` を忘れていないか」と原因が即座に分かります。

**CONTRIBUTING.md にメンテナ向けのリリース手順を追記**。`npm version` → push → GitHub Release の流れを明記し、そもそもタグと package.json がズレないようにします。

## 動作確認（ローカルでロジックをシミュレート）

```
tag=1.2.14 pkg=1.2.14 → 一致（publish 続行）
tag=1.2.99 pkg=1.2.14 → 不一致（fail = 今回の 1.2.14 事故を事前に検出）
```

YAML の構文も検証済み。実際の publish ワークフローは Release 公開時にしか発火しないため、次のリリースで初めて本番動作します。

## Checklist

- [x] publish 前にタグ名と package.json version の一致を検証し、不一致なら明示的なメッセージで落とす
- [x] リリース手順がドキュメント化されている（CONTRIBUTING.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
