### PR TITLE
docs: document the fork-PR CI approval flow for maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,3 +112,32 @@ and npm rejects it with `cannot publish over the previously published
 versions`. The publish workflow now fails fast with a clear message when
 the tag and `package.json` disagree, but the correct fix is always to bump
 the version with `npm version`.
+
+## Reviewing fork pull requests (maintainers)
+
+CI does not run automatically on a pull request from a first-time
+contributor's fork — GitHub holds the workflow with an `action_required`
+status until a maintainer approves it. This is deliberate: `publish.yml`
+runs with `id-token` and npm publish rights, and hostswitch itself runs
+under `sudo`, so letting unreviewed fork code trigger workflows is a risk
+we don't want to take. The approval gate stays on.
+
+When a fork PR comes in:
+
+1. **Read the diff first**, before approving CI. Pay attention to anything
+   touching `.github/workflows/`, `package.json`, `package-lock.json`, or
+   install scripts — those are the parts that could abuse the CI
+   environment. A docs- or source-only change is low risk.
+2. Approve the run once the diff looks safe:
+
+   ```bash
+   gh run list --branch <fork-branch> --json databaseId,conclusion \
+     --jq '.[] | select(.conclusion=="action_required") | .databaseId'
+   gh api -X POST repos/milkmaccya2/hostswitch/actions/runs/<id>/approve
+   ```
+
+   (or click **Approve and run** on the PR's Checks tab).
+3. Let the matrix finish, then review and merge as usual.
+
+The `main` branch requires the `Lint, Build & Test` check to pass, so a PR
+can't be merged until its CI has been approved and is green.


### PR DESCRIPTION
## Summary

外部コントリビュータのフォーク PR（#90 / #93 / #108 が実際にこれに当たった）で CI が `action_required` で止まり、`main` は `Lint, Build & Test` を必須にしているため、メンテナが承認するまで PR が進めない件です。

## Related Issue

Closes #103

## 方針: 承認ゲートは残す（案A）

`publish.yml` は `id-token` と npm publish 権限を持ち、hostswitch 自体が sudo で動くため、**未レビューのフォークコードで CI を無条件に走らせるのは避けるべき**です。ゲートを緩めるのではなく、**承認手順をドキュメント化**して「気づきの遅れ」だけを潰す方向にします。

## 変更

CONTRIBUTING.md に「Reviewing fork pull requests (maintainers)」節を追加:

1. **承認前に diff を読む** — 特に `.github/workflows/` / `package.json` / `package-lock.json` / install スクリプトに触れていないか。docs/src のみなら低リスク
2. 安全を確認したら CI を承認（`gh api -X POST .../actions/runs/<id>/approve` または Checks タブの Approve and run）
3. matrix 完了後、通常どおりレビュー & マージ

## なぜコード変更なしか

これは GitHub の設定（フォーク PR のワークフロー承認）とメンテナ運用の話で、リポジトリのコードで解決するものではありません。「承認を外す」のはセキュリティ上非推奨（sudo で動く npm パッケージ）なので、**運用を明文化する**のが最も妥当な着地です。

## Checklist

- [x] フォーク PR の CI 承認方針が決まっている（案A: 承認を残す）
- [x] 承認手順が CONTRIBUTING.md に書かれている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
