### PR TITLE
test: cover the UI display and interactive menu flows

### DIFF
--- a/src/cli/ui/__tests__/UserInterface.test.ts
+++ b/src/cli/ui/__tests__/UserInterface.test.ts
@@ -22,6 +22,7 @@ describe('User Interface Classes', () => {
       elevate: vi.fn(),
       getCurrentProfile: vi.fn(),
       getDeletableProfiles: vi.fn(),
+      validateProfileNameInput: vi.fn().mockReturnValue(true),
     } as unknown as HostSwitchFacade;
 
     mockLogger = {
@@ -151,6 +152,135 @@ describe('User Interface Classes', () => {
         expect(mockLogger.warning).toHaveBeenCalledWith(
           'Run `hostswitch switch nothing` to apply to /etc/hosts.'
         );
+      });
+    });
+
+    describe('displayData', () => {
+      it('プロファイル一覧を current 付きで表示する', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: {
+            profiles: [
+              { name: 'dev', isCurrent: true },
+              { name: 'stg', isCurrent: false },
+            ],
+          },
+        });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('  dev (current)');
+        expect(mockLogger.info).toHaveBeenCalledWith('  stg');
+      });
+
+      it('プロファイルが空なら No profiles found', async () => {
+        await cliUI.handleCommandResult({ success: true, data: { profiles: [] } });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('No profiles found');
+      });
+
+      it('バックアップ一覧を日時付きで表示する', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: {
+            backups: [{ id: '2026-08-05T14-32-10-123Z', path: '/b', createdAt: new Date(0) }],
+          },
+        });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('Available backups (newest first):');
+        const printed = vi
+          .mocked(mockLogger.info)
+          .mock.calls.map((c) => c[0])
+          .join('\n');
+        expect(printed).toContain('2026-08-05T14-32-10-123Z');
+      });
+
+      it('createdAt が null のバックアップは unknown time と表示する', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: { backups: [{ id: 'manual', path: '/b', createdAt: null }] },
+        });
+
+        const printed = vi
+          .mocked(mockLogger.info)
+          .mock.calls.map((c) => c[0])
+          .join('\n');
+        expect(printed).toContain('unknown time');
+      });
+
+      it('バックアップが空なら No backups found', async () => {
+        await cliUI.handleCommandResult({ success: true, data: { backups: [] } });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('No backups found');
+      });
+
+      it('プロファイル内容をそのまま出力する', async () => {
+        const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        await cliUI.handleCommandResult({
+          success: true,
+          data: { content: '127.0.0.1 example.local' },
+        });
+
+        expect(spy).toHaveBeenCalledWith('127.0.0.1 example.local');
+        spy.mockRestore();
+      });
+    });
+
+    describe('displayStatus', () => {
+      const baseStatus = {
+        currentProfile: 'dev',
+        hostsPath: '/etc/hosts',
+        modified: false,
+        updatedAt: null as string | null,
+        latestBackup: null as { id: string; path: string; createdAt: Date | null } | null,
+      };
+
+      it('in sync の状態を表示する', async () => {
+        await cliUI.handleCommandResult({ success: true, data: { status: baseStatus } });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('Current profile: dev');
+        expect(mockLogger.info).toHaveBeenCalledWith('Status:          in sync');
+      });
+
+      it('current が無ければ no profile active', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: { status: { ...baseStatus, currentProfile: null } },
+        });
+
+        expect(mockLogger.info).toHaveBeenCalledWith('Current profile: (none)');
+        expect(mockLogger.info).toHaveBeenCalledWith('Status:          no profile active');
+      });
+
+      it('modified なら警告とTipを出す', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: { status: { ...baseStatus, modified: true } },
+        });
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          'Status:          modified outside hostswitch'
+        );
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining('--from-current'));
+      });
+
+      it('updatedAt と latestBackup があれば表示する', async () => {
+        await cliUI.handleCommandResult({
+          success: true,
+          data: {
+            status: {
+              ...baseStatus,
+              updatedAt: '2026-08-05T14:32:10.000Z',
+              latestBackup: { id: 'bk1', path: '/b', createdAt: new Date(0) },
+            },
+          },
+        });
+
+        const printed = vi
+          .mocked(mockLogger.info)
+          .mock.calls.map((c) => c[0])
+          .join('\n');
+        expect(printed).toContain('Last switched:');
+        expect(printed).toContain('Latest backup:   bk1');
       });
     });
   });
@@ -520,6 +650,84 @@ describe('User Interface Classes', () => {
 
         await interactiveUI.run();
 
+        expect(mockFacade.deleteProfile).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('run() - show', () => {
+      it('選んだプロファイルの内容を表示する', async () => {
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: { profiles: [{ name: 'dev', isCurrent: false }] },
+        });
+        vi.mocked(mockFacade.showProfile).mockResolvedValue({
+          success: true,
+          data: { content: '127.0.0.1 dev.local' },
+        });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'show' })
+          .mockResolvedValueOnce({ selected: 'dev' })
+          // show の後の「Press Enter to continue」
+          .mockResolvedValueOnce({ input: '' });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.showProfile).toHaveBeenCalledWith('dev');
+        expect(mockLogger.info).toHaveBeenCalledWith('127.0.0.1 dev.local');
+      });
+
+      it('プロファイルが無ければ警告して何もしない', async () => {
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: { profiles: [] },
+        });
+        vi.mocked(inquirer.prompt).mockResolvedValueOnce({ selected: 'show' });
+
+        await interactiveUI.run();
+
+        expect(mockLogger.warning).toHaveBeenCalledWith('No profiles available to show');
+        expect(mockFacade.showProfile).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('run() - create', () => {
+      it('名前を入力し from-current を確認して作成する', async () => {
+        vi.mocked(mockFacade.validateProfileNameInput).mockReturnValue(true);
+        vi.mocked(mockFacade.createProfile).mockResolvedValue({ success: true });
+        vi.mocked(inquirer.prompt)
+          .mockResolvedValueOnce({ selected: 'create' })
+          .mockResolvedValueOnce({ input: 'newone' })
+          .mockResolvedValueOnce({ confirmed: true });
+
+        await interactiveUI.run();
+
+        expect(mockFacade.createProfile).toHaveBeenCalledWith('newone', true);
+      });
+    });
+
+    describe('run() - edit の早期リターン', () => {
+      it('プロファイルが無ければ警告して何もしない', async () => {
+        vi.mocked(mockFacade.listProfiles).mockResolvedValue({
+          success: true,
+          data: { profiles: [] },
+        });
+        vi.mocked(inquirer.prompt).mockResolvedValueOnce({ selected: 'edit' });
+
+        await interactiveUI.run();
+
+        expect(mockLogger.warning).toHaveBeenCalledWith('No profiles available to edit');
+        expect(mockFacade.editProfile).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('run() - delete の早期リターン', () => {
+      it('削除可能なプロファイルが無ければ警告して何もしない', async () => {
+        vi.mocked(mockFacade.getDeletableProfiles).mockReturnValue([]);
+        vi.mocked(inquirer.prompt).mockResolvedValueOnce({ selected: 'delete' });
+
+        await interactiveUI.run();
+
+        expect(mockLogger.warning).toHaveBeenCalledWith('No profiles available for deletion');
         expect(mockFacade.deleteProfile).not.toHaveBeenCalled();
       });
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
       // 現状値（lines/statements 83%, branches 84%, functions 91%）から
       // 少し下に置く。ここを割ったら CI が落ちる
       thresholds: {
-        lines: 80,
-        statements: 80,
-        branches: 78,
-        functions: 85,
+        lines: 85,
+        statements: 85,
+        branches: 82,
+        functions: 90,
       },
     },
   },


### PR DESCRIPTION
## Summary

#83 の残タスク（CLI/UI 層のカバレッジ向上）です。道具立て（テストの型チェック / 閾値 / モック・型定義の除外）は #101 で完了済みだったので、ここでは実際にテストを書き足します。

## Related Issue

Closes #83

## 追加したテスト

UI 層はコードベースで最も薄く、`cli/ui` が ~74% でした。特に以下が未テストでした:

- **`CliUserInterface.displayData`** — プロファイル一覧 / バックアップ一覧（日時あり・なし）/ 空ケース / プロファイル内容の raw 出力
- **`CliUserInterface.displayStatus`**（#81 で追加）— in sync / no profile / modified の3状態、Last switched・Latest backup 行
- **`InteractiveUserInterface.run()`** — show / create のフロー、および show / edit / delete の「プロファイル無し」early-return

## カバレッジ

- `cli/ui`: **~74% → ~92%**
- 全体: **~83% → ~90%**
- テスト: **316 → 331件**

改善分を固定するため、**閾値を引き上げ**ました:

| | before | after |
| --- | --- | --- |
| lines / statements | 80 | **85** |
| branches | 78 | **82** |
| functions | 85 | **90** |

## 補足

`mockLogger.info.mock.calls` を参照する箇所で、#101 の**テスト型チェックが型エラーを検出**しました（`ILogger` 型では `.mock` が見えない）。`vi.mocked()` でラップして解消しています。型チェックが機能している良い例です。

## Checklist

- [x] `npm run check` passes locally（typecheck 含む、**331 tests**）
- [x] `cli/ui` のカバレッジが大幅に向上
- [x] 閾値を引き上げて回帰を検知しやすくした

🤖 Generated with [Claude Code](https://claude.com/claude-code)
