### PR TITLE
docs: state that native Windows is not officially supported

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,10 @@ Running `hostswitch` without any arguments launches an interactive mode:
 1. **Hosts File Path**: Automatically detects OS
    - Unix/Linux/macOS: `/etc/hosts`
    - Windows: `C:\Windows\System32\drivers\etc\hosts`
+   - **Supported platforms are macOS and Linux** (including WSL). The Windows
+     path is detected, but native Windows is not officially supported — the
+     `postbuild` `chmod` breaks the source build there (see #78). Don't invest
+     in native-Windows behavior without revisiting that decision.
 2. **Editor Selection**: Uses `$EDITOR` environment variable, falls back to `vi`
 3. **Profile Validation**: Cannot delete currently active profile
 4. **Backup Strategy**: Only backs up if hosts file was modified or no current profile exists. The most recent 20 backups are kept; older ones are pruned on each switch/restore. Restore replays a backup through the same atomic write path as switch and clears the current profile afterwards

--- a/README.ja.md
+++ b/README.ja.md
@@ -31,7 +31,7 @@ HostSwitchは、開発環境やテスト環境で異なるhosts設定を簡単�
 ## 要件
 
 - Node.js 20.0.0以上
-- macOS / Linux / Windows (WSL推奨)
+- **対応プラットフォーム: macOS / Linux**（WSL 経由の Windows も含む。WSL は Linux として動作します）。ネイティブ Windows は正式サポート対象外です — 下の [Windows](#windows) を参照
 - sudo権限（hostsファイル切り替え時）
 
 ## インストール
@@ -321,11 +321,11 @@ hostswitch delete 破損プロファイル --force
 hostswitch create 破損プロファイル --from-current
 ```
 
-### Windowsでの使用
+### Windows
 
-WindowsではWSL (Windows Subsystem for Linux)の使用を推奨します。ネイティブWindowsで使用する場合は、管理者権限でコマンドプロンプトを実行してください。
+**ネイティブ Windows は正式サポート対象外です。** **WSL (Windows Subsystem for Linux)** の使用を推奨します（WSL は Linux として動作し、完全にサポートされます）。
 
-**注意**: ネイティブWindowsサポートが改善されました。Windowsのhostsファイルパス（`C:\Windows\System32\drivers\etc\hosts`）を自動的に検出します。
+コードは Windows の hosts パス（`C:\Windows\System32\drivers\etc\hosts`）を検出し、管理者権限で npm 版が動く場合もありますが、テスト・サポート対象外です。ソースからのビルドは現在ネイティブ Windows では失敗します（`postbuild` の `chmod` のため）。ネイティブ Windows を正式対応にする作業に協力いただける場合は [#78](https://github.com/milkmaccya2/hostswitch/issues/78) を参照してください。
 
 ## データ保存場所
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ HostSwitch is a CLI tool that makes it easy to switch between different hosts co
 ## Requirements
 
 - Node.js 20.0.0 or higher
-- macOS / Linux / Windows (WSL recommended)
+- **Supported platforms: macOS and Linux** (including Windows via WSL, which runs as Linux). Native Windows is not officially supported — see [Windows](#windows) below.
 - sudo permissions (for hosts file switching)
 
 ## Installation
@@ -299,11 +299,11 @@ hostswitch delete corrupted-profile --force
 hostswitch create corrupted-profile --from-current
 ```
 
-### Windows Usage
+### Windows
 
-For Windows, we recommend using WSL (Windows Subsystem for Linux). If using native Windows, run Command Prompt as Administrator.
+**Native Windows is not officially supported.** Use **WSL (Windows Subsystem for Linux)**, which runs as Linux and is fully supported.
 
-**Note**: Native Windows support has been improved. The tool now automatically detects the Windows hosts file location (`C:\Windows\System32\drivers\etc\hosts`).
+The code does detect the Windows hosts path (`C:\Windows\System32\drivers\etc\hosts`), and installing from npm may work when run as Administrator, but this is not tested or supported. Building from source currently fails on native Windows (the `postbuild` step uses `chmod`). If you want to help make native Windows a first-class target, see [#78](https://github.com/milkmaccya2/hostswitch/issues/78).
 
 ## Data Storage
 


### PR DESCRIPTION
## Summary

README が「macOS / Linux / Windows (WSL recommended)」「Native Windows support has been improved」と書いており、**#78 の決定（ネイティブ Windows は正式サポートしない）と矛盾**していました。ドキュメントを実態と決定に揃えます。

## Related Issue

Refs #78（この Issue は実装判断が残るため open のまま。ドキュメント整合のみ対応）

## 変更

README.md / README.ja.md / CLAUDE.md を修正:

- **対応プラットフォームは macOS / Linux**（WSL 経由の Windows を含む。WSL は Linux として動作）
- **ネイティブ Windows は正式サポート対象外**と明記。hosts パスは検出するが、ソースビルドは `postbuild` の `chmod` で失敗する旨も正直に記載
- 協力したい人向けに #78 へのリンク

挙動変更はありません（Windows の hosts パス検出はそのまま）。過剰約束していた "Native Windows support has been improved" の記述を削除しました。

## なぜ #78 を close しないか

方針（正式サポートしない）は決定済みですが、#78 には「`postbuild` の chmod をどうするか」等の実装判断が残るため、当初の方針どおり **open のまま**にします。このPRは「対応OSの明記」という、方針と整合する部分だけを対応します。

## Checklist

- [x] `npm run check` passes locally
- [x] 対応OSが3つのドキュメントで一貫している
- [x] 過剰約束の Windows 記述を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
